### PR TITLE
SDK: Add KDoc backfill, Detekt lint gate, Dokka CI, and sdk-docs skill

### DIFF
--- a/.agents/skills/sdk-docs/SKILL.md
+++ b/.agents/skills/sdk-docs/SKILL.md
@@ -88,7 +88,7 @@ Match naming used in `frame-ios` and `frame-js` / `frame-react-native` for equiv
 ## What NOT to document
 
 - Implementation details or internal state invisible to callers.
-- Obvious getters/setters where the property name is fully self-documenting and there are no constraints or side effects to describe.
+- Truly self-evident properties where the name carries the full contract and there are no constraints, side effects, or non-obvious nullability to describe. Note: Detekt enforces `UndocumentedPublicProperty` with no exceptions — use `@Suppress("UndocumentedPublicProperty")` on the declaration if you genuinely need to skip one, and leave a code comment explaining why.
 - Private or internal symbols.
 
 ## Existing symbols

--- a/.agents/skills/sdk-docs/SKILL.md
+++ b/.agents/skills/sdk-docs/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: sdk-docs
+description: How to author KDoc comments on public symbols in frame-android. Loaded automatically when an agent is writing or editing KDoc in this repo.
+---
+
+# frame-android — KDoc authoring
+
+KDoc on public symbols is the source of truth for the Frame Android SDK reference docs. Dokka reads these comments to generate HTML output hosted at the stable URL linked from the Frame SDK orientation page.
+
+## Central standards (read first)
+
+Cross-SDK style, terminology, and naming live in `frame-docs/lib/sdk-docs-standards/`. They override anything in this file.
+
+1. **Local first** — if `~/Development/frame-docs/lib/sdk-docs-standards/` exists, read `STYLE.md`, `EXAMPLES.md`, and `CROSS_SDK_NAMING.md` from there.
+2. **GitHub fallback** — otherwise fetch from `https://github.com/Frame-Payments/frame-docs/tree/main/lib/sdk-docs-standards/` (requires `gh` auth; the repo is private).
+3. **If absent** — those documents don't exist yet. Use this file as the baseline until they do.
+
+## Public surface
+
+Every `public` or `open` Kotlin symbol in the three SDK modules requires a KDoc block:
+
+* **FrameSDK** (`com.framepayments.framesdk`) — API classes, data classes, request/response objects, enums, interfaces.
+* **FrameSDK-UI** (`com.framepayments.framesdk_ui`) — public Compose components, view models, validation helpers.
+* **FrameSDK-Onboarding** (`com.framepayments.frameonboarding`) — public onboarding classes, view models, Compose screens exposed to integrators.
+
+Internal-only classes (`private`, `internal`) do not require KDoc. If an internal type surfaces in a public signature, document it at the use site with a `@see` link rather than adding KDoc to the internal symbol.
+
+## Format
+
+All public symbols require a `/** ... */` KDoc block. Use `//` single-line comments only for implementation notes inside function bodies.
+
+```kotlin
+/**
+ * A brief one-line summary ending with a period.
+ *
+ * Extended discussion when needed. Keep it concise and caller-focused.
+ *
+ * @param param Description of this parameter.
+ * @return What the function returns.
+ * @throws ExceptionType When this is thrown.
+ */
+public fun exampleFunction(param: String): Boolean { ... }
+```
+
+For data classes, document the class itself and each constructor property:
+
+```kotlin
+/**
+ * Options for presenting the checkout sheet.
+ *
+ * @property clientSecret Short-lived token from the merchant's `POST /charge-intents`. Always starts with `cs_`.
+ * @property items Line items to display in the cart.
+ */
+public data class CheckoutOptions(
+    val clientSecret: String,
+    val items: List<CartItem>,
+)
+```
+
+## Summary line
+
+- One sentence, active voice. Functions: imperative ("Submits the payment"). Types/properties: noun phrase ("A checkout flow coordinator").
+- End with a period.
+- No redundant prefixes like "This class…" or "A function that…".
+
+## Tags
+
+* **`@param`** / **`@property`** — every parameter and constructor property on public API. Say what the value means, not just its type.
+* **`@return`** — what the caller gets back. Omit only for `Unit`-returning functions with no meaningful result.
+* **`@throws`** — every exception the function can propagate to callers.
+* **`@sample`** — at least one realistic merchant-side calling example for entry-point classes and functions.
+* **`@see`** — link related symbols using `[ClassName]` or `[ClassName.methodName]` syntax.
+* **`@deprecated`** — when retiring, include migration guidance inline.
+
+## Voice and terminology (baseline; central standards override)
+
+* Active voice, caller-facing perspective. "Presents the checkout sheet." Not "The checkout sheet is presented."
+* **Merchant** = the integrating app developer. **Customer** = the merchant's end user.
+* **Card** (not "credit card" — debit is supported).
+* **Publishable key** for `pk_...`, **secret key** for `sk_...`, **client secret** for `cs_...`.
+* Examples use `pk_test_...` / `sk_test_...`, never live keys.
+* When behavior differs between API levels or SDK versions, use `@throws` or inline prose rather than leaving it undocumented.
+
+## Cross-SDK naming
+
+Match naming used in `frame-ios` and `frame-js` / `frame-react-native` for equivalent concepts. Check `CROSS_SDK_NAMING.md` before introducing new terminology.
+
+## What NOT to document
+
+- Implementation details or internal state invisible to callers.
+- Obvious getters/setters where the property name is fully self-documenting and there are no constraints or side effects to describe.
+- Private or internal symbols.
+
+## Existing symbols
+
+Existing public symbols without KDoc are tracked in [FRA-3959](https://linear.app/framepayments/issue/FRA-3959) (KDoc backfill). When touching an undocumented symbol, add a KDoc block. New public symbols must always have KDoc — CI will fail otherwise (Detekt `UndocumentedPublicClass` / `UndocumentedPublicFunction` / `UndocumentedPublicProperty`).
+
+## Lint gate
+
+Detekt KDoc rules are enforced on this repo. CI fails on any public symbol missing a `/** ... */` block. Run `./gradlew detekt` locally before pushing.

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,7 +56,7 @@ jobs:
           path: "**/build/reports/detekt/**"
 
   build-and-test:
-    needs: theme-lint
+    needs: [theme-lint, kdoc-lint]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,6 +25,36 @@ jobs:
       - name: Theme lint (block hardcoded colors / fonts / radii in SDK UI)
         run: ./scripts/theme-lint.sh
 
+  kdoc-lint:
+    # Fails if any public symbol in the SDK modules is missing a KDoc block.
+    # Gate for the KDoc backfill (FRA-3959): new public symbols must be documented from day one.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: KDoc lint (Detekt — UndocumentedPublicClass/Function/Property)
+        run: ./gradlew :FrameSDK:detekt :FrameSDK-UI:detekt :FrameSDK-Onboarding:detekt --stacktrace
+
+      - name: Upload Detekt reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detekt-reports
+          path: "**/build/reports/detekt/**"
+
   build-and-test:
     needs: theme-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Publish SDK Docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '[0-9]*'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@b5418f5a58f5fd2eb486dd7efb368fe7be7eae45
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Generate Dokka HTML
+        run: ./gradlew :FrameSDK:dokkaHtml :FrameSDK-UI:dokkaHtml :FrameSDK-Onboarding:dokkaHtml --stacktrace
+
+      - name: Assemble docs site
+        run: |
+          mkdir -p _site/framesdk _site/framesdk-ui _site/framesdk-onboarding
+          cp -r FrameSDK/build/dokka/html/. _site/framesdk/
+          cp -r FrameSDK-UI/build/dokka/html/. _site/framesdk-ui/
+          cp -r FrameSDK-Onboarding/build/dokka/html/. _site/framesdk-onboarding/
+          # Root index redirects to the core SDK docs
+          cat > _site/index.html <<'EOF'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>Frame Android SDK Docs</title>
+          <meta http-equiv="refresh" content="0; url=framesdk/">
+          <a href="framesdk/">Frame Android SDK Docs →</a>
+          EOF
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy-docs:
+    needs: build-docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/FrameSDK-Onboarding/build.gradle.kts
+++ b/FrameSDK-Onboarding/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     kotlin("android") version "2.2.10"
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.vanniktech.maven.publish")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.dokka)
 }
 
 android {
@@ -115,6 +117,16 @@ mavenPublishing {
     publishToMavenCentral(automaticRelease = true)
     signAllPublications()
 }
+detekt {
+    config.setFrom(rootProject.file("config/detekt/detekt.yml"))
+    source.setFrom("src/main/java")
+    autoCorrect = false
+}
+
+tasks.named("dokkaHtml") {
+    outputs.upToDateWhen { false }
+}
+
 // CI: print per-test pass/fail names instead of the silent default. Helps surface
 // which API tests actually ran when reviewing the Android CI workflow logs.
 tasks.withType<Test> {

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/classes/AddressFormat.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/classes/AddressFormat.kt
@@ -3,7 +3,15 @@ package com.framepayments.frameonboarding.classes
 import androidx.compose.ui.text.input.KeyboardType
 
 /**
- * Per-country address field format hints. 1:1 port of iOS AddressFormat.
+ * Per-country address field format hints used to configure the billing address form.
+ *
+ * Mirrors iOS `AddressFormat`. Use [AddressFormat.format] to retrieve the format for a
+ * specific country; unknown countries fall back to a generic international format.
+ *
+ * @property stateLabel Localized label for the state/province field (e.g. "State", "Province").
+ * @property postalLabel Localized label for the postal code field (e.g. "Zip Code", "Postcode").
+ * @property postalKeyboard Keyboard type to use for the postal code input field.
+ * @property stateMaxLength Maximum character length for the state field, or null if unconstrained.
  */
 data class AddressFormat(
     val stateLabel: String,
@@ -11,6 +19,7 @@ data class AddressFormat(
     val postalKeyboard: KeyboardType,
     val stateMaxLength: Int?
 ) {
+    /** Factory methods and per-country format table. */
     companion object {
         private val DEFAULT = AddressFormat(
             stateLabel = "State",
@@ -38,6 +47,13 @@ data class AddressFormat(
             "SG" to AddressFormat("Region", "Postal Code", KeyboardType.Number, null)
         )
 
+        /**
+         * Returns the [AddressFormat] for the given country code, falling back to a generic
+         * international format for unsupported countries.
+         *
+         * @param forCountry ISO 3166-1 alpha-2 country code (case-insensitive).
+         * @return The country-specific [AddressFormat], or a generic fallback.
+         */
         fun format(forCountry: String): AddressFormat =
             formats[forCountry.uppercase()] ?: DEFAULT
     }

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/classes/Onboarding.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/classes/Onboarding.kt
@@ -17,42 +17,82 @@ internal class OnboardingState(
     }
 }
 
+/**
+ * Represents a single screen in the onboarding flow.
+ *
+ * The ordered list of steps is computed from [OnboardingConfig.requiredCapabilities] by
+ * [com.framepayments.frameonboarding.classes.computeOrderedSteps]. Merchants do not create
+ * or navigate steps directly; use [OnboardingContainerView] to drive the full flow.
+ */
 sealed class OnboardingStep {
+    /** Introductory welcome screen shown at the start of the flow. */
     data object VerificationWelcome: OnboardingStep()
+    /** Screen collecting personal information and phone/DOB for identity verification. */
     data object VerifyIdentification: OnboardingStep()
+    /** Screen checking the customer's geolocation for compliance. */
     data object GeolocationVerification: OnboardingStep()
+    /** Screen listing the customer's existing payment methods for selection. */
     data object SelectPaymentMethod: OnboardingStep()
+    /** Screen for adding a new payment Card. */
     data object AddPaymentMethod: OnboardingStep()
+    /** Screen for verifying the customer's Card via 3D Secure. */
     data object VerifyYourCard: OnboardingStep()
+    /** Screen listing the customer's existing payout methods for selection. */
     data object SelectPayoutMethod: OnboardingStep()
+    /** Screen for adding a new payout method (bank account). */
     data object AddPayoutMethod: OnboardingStep()
+    /** Screen listing the identity documents the customer must upload. */
     data object UploadDocumentsList: OnboardingStep()
+    /** Camera screen for capturing the front of the customer's ID document. */
     data object CaptureFrontPhoto: OnboardingStep()
+    /** Review screen for the front-of-ID photo before submission. */
     data object ReviewFrontPhoto: OnboardingStep()
+    /** Camera screen for capturing the back of the customer's ID document. */
     data object CaptureBackPhoto: OnboardingStep()
+    /** Review screen for the back-of-ID photo before submission. */
     data object ReviewBackPhoto: OnboardingStep()
+    /** Camera screen for capturing a selfie. */
     data object CaptureSelfie: OnboardingStep()
+    /** Review screen for the selfie photo before submission. */
     data object ReviewSelfie: OnboardingStep()
+    /** Confirmation screen shown after all verification data has been submitted. */
     data object VerificationSubmitted: OnboardingStep()
 }
 
 /**
- * Capability names matching the backend and iOS FrameObjects.Capabilities.
- * Used to drive which onboarding steps are shown (capability-driven flow).
+ * Capability names that map to backend capability strings and drive the onboarding step sequence.
+ *
+ * Pass one or more values in [OnboardingConfig.requiredCapabilities] to control which screens
+ * appear in the flow. Mirrors the iOS `FrameObjects.Capabilities` enum.
+ *
+ * @property apiValue The backend API string for this capability.
  */
 enum class Capabilities(val apiValue: String) {
+    /** Know Your Customer identity verification. */
     KYC("kyc"),
+    /** KYC with pre-filled identity data via Prove. */
     KYC_PREFILL("kyc_prefill"),
+    /** Phone number verification via OTP. */
     PHONE_VERIFICATION("phone_verification"),
+    /** Creator Shield fraud-protection capability. */
     CREATOR_SHIELD("creator_shield"),
+    /** Card ownership verification via 3D Secure. */
     CARD_VERIFICATION("card_verification"),
+    /** Ability to send funds from a Card. */
     CARD_SEND("card_send"),
+    /** Ability to receive funds to a Card. */
     CARD_RECEIVE("card_receive"),
+    /** Billing address verification. */
     ADDRESS_VERIFICATION("address_verification"),
+    /** Bank account ownership verification. */
     BANK_ACCOUNT_VERIFICATION("bank_account_verification"),
+    /** Ability to send funds from a bank account. */
     BANK_ACCOUNT_SEND("bank_account_send"),
+    /** Ability to receive funds to a bank account. */
     BANK_ACCOUNT_RECEIVE("bank_account_receive"),
+    /** Geographic compliance check. */
     GEO_COMPLIANCE("geo_compliance"),
+    /** Age verification (must be 18+). */
     AGE_VERIFICATION("age_verification")
 }
 
@@ -151,34 +191,53 @@ internal fun OnboardingStep.toFlowSegment(): OnboardingFlowSegment = when (this)
     OnboardingStep.VerificationSubmitted -> OnboardingFlowSegment.VERIFICATION_SUBMITTED
 }
 
+/**
+ * Terminal outcome of an onboarding session delivered to the merchant via the
+ * [OnboardingContainerView] `onResult` callback.
+ */
 sealed class OnboardingResult {
+    /** The customer dismissed the onboarding flow before completing all steps. */
     data object Cancelled : OnboardingResult()
+
+    /**
+     * All required capability steps were completed.
+     *
+     * @property paymentMethodId ID of the payment method added during the flow, if any.
+     */
     data class Completed(
         val paymentMethodId: String?
     ) : OnboardingResult()
+
+    /**
+     * The onboarding flow encountered an unrecoverable error.
+     *
+     * @property message Human-readable description of the failure.
+     */
     data class Failed(val message: String) : OnboardingResult()
 }
 
+/**
+ * Configuration for an onboarding session passed to [OnboardingContainerView].
+ *
+ * @property accountId Pre-existing Frame account ID to resume onboarding for, or null to create
+ *   a new account during the flow.
+ * @property requiredCapabilities Capabilities the customer must satisfy; determines which
+ *   onboarding steps are shown.
+ * @property skipInitNetwork When true, suppresses network calls during ViewModel init (for
+ *   Compose previews and design tools).
+ * @property theme Optional [FrameTheme] applied to all onboarding screens. Defaults to
+ *   [FrameTheme.default] when null.
+ * @property showIntroScreen When false, the "Verify Your Identity" welcome screen is omitted
+ *   and the first capability-driven step is shown immediately.
+ * @property showCompletionScreen When false, the "Verification Submitted" screen is omitted
+ *   and the flow completes immediately after the last capability step.
+ */
 data class OnboardingConfig(
     val accountId: String? = null,
     val requiredCapabilities: List<Capabilities> = emptyList(),
-    /**
-     * When true, [FrameOnboardingViewModel] skips network work in `init` (Compose Preview / design tools).
-     */
     val skipInitNetwork: Boolean = false,
-    /**
-     * Optional theme override applied to all onboarding screens. When null, [FrameTheme.default]
-     */
     val theme: FrameTheme? = null,
-    /**
-     * When false, the "Verify Your Identity" intro screen is skipped and the first
-     * capability-driven step is shown immediately. Defaults to true.
-     */
     val showIntroScreen: Boolean = true,
-    /**
-     * When false, the "Verification Submitted" completion screen is skipped and the flow
-     * completes immediately after the last capability step. Defaults to true.
-     */
     val showCompletionScreen: Boolean = true,
 )
 
@@ -195,6 +254,15 @@ internal enum class PhotoType {
     SELFIE
 }
 
+/**
+ * Mutable draft state for the manual card entry form used when Evervault UI is unavailable.
+ *
+ * @property cardNumber Raw card number digits as entered by the customer.
+ * @property expiryMonth Two-digit expiration month (e.g. "01").
+ * @property expiryYear Two- or four-digit expiration year (e.g. "26" or "2026").
+ * @property cvc Three- or four-digit card security code.
+ * @property useForPayouts When true, the customer intends to use this card for payouts as well.
+ */
 data class PaymentCardDraft(
     val cardNumber: String = "",
     val expiryMonth: String = "",
@@ -203,6 +271,13 @@ data class PaymentCardDraft(
     val useForPayouts: Boolean = false
 )
 
+/**
+ * Mutable draft state for the ACH bank account form.
+ *
+ * @property routingNumber US 9-digit ABA routing number.
+ * @property accountNumber Bank account number (4–17 digits).
+ * @property accountTypeLabel Human-readable account type selected by the customer ("Checking" or "Savings").
+ */
 data class BankAccountDraft(
     val routingNumber: String = "",
     val accountNumber: String = "",

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/classes/PhoneCountrySelection.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/classes/PhoneCountrySelection.kt
@@ -4,18 +4,28 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil
 import java.util.Locale
 
 /**
- * Country selection for the phone number entry. 1:1 port of iOS PhoneCountrySelection.
+ * Represents a country selection in the phone number entry field.
+ *
+ * Provides the dial code prefix, Unicode flag emoji, and localized display name for a given
+ * ISO 3166-1 alpha-2 region code. Mirrors iOS `PhoneCountrySelection`.
+ *
+ * @property alpha2 ISO 3166-1 alpha-2 country code (e.g. "US").
+ * @property dialCode E.164 dial code prefix including the leading "+" (e.g. "+1").
  */
 data class PhoneCountrySelection(
     val alpha2: String,
     val dialCode: String
 ) {
+    /** Unicode flag emoji for this country derived from [alpha2]. */
     val flag: String get() = flagFor(alpha2)
+
+    /** Localized display name of this country in the device's default locale. */
     val displayName: String
         get() = Locale.Builder().setRegion(alpha2).build()
             .getDisplayCountry(Locale.getDefault())
             .ifEmpty { alpha2 }
 
+    /** Factory methods, country list, and OFAC restriction set for the phone picker. */
     companion object {
         /** Countries excluded from address & phone pickers per OFAC compliance. Mirrors iOS. */
         val OFAC_RESTRICTED: Set<String> = setOf(
@@ -33,6 +43,10 @@ data class PhoneCountrySelection(
             return sb.toString()
         }
 
+        /**
+         * Lazily built list of all supported regions sorted alphabetically by display name,
+         * with OFAC-restricted countries excluded.
+         */
         val all: List<PhoneCountrySelection> by lazy {
             val util = PhoneNumberUtil.getInstance()
             util.supportedRegions
@@ -45,12 +59,23 @@ data class PhoneCountrySelection(
                 .sortedBy { it.displayName }
         }
 
+        /**
+         * The default selection for the current device locale; falls back to "US" when the
+         * locale region is unavailable or OFAC-restricted.
+         */
         val default: PhoneCountrySelection
             get() {
                 val region = Locale.getDefault().country.takeIf { it.length == 2 } ?: "US"
                 return find(region) ?: find("US") ?: PhoneCountrySelection("US", "+1")
             }
 
+        /**
+         * Finds the [PhoneCountrySelection] for the given [alpha2] code, or null if the country
+         * is not in [all] (e.g. it is OFAC-restricted or unsupported).
+         *
+         * @param alpha2 ISO 3166-1 alpha-2 country code to look up (case-insensitive).
+         * @return The matching [PhoneCountrySelection], or null if not found.
+         */
         fun find(alpha2: String): PhoneCountrySelection? {
             val key = alpha2.uppercase()
             return all.firstOrNull { it.alpha2 == key }

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceAPI.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceAPI.kt
@@ -3,22 +3,28 @@ package com.framepayments.frameonboarding.networking.geocompliance
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/** API methods for fetching geofences and account geo-compliance status. */
 object GeocomplianceAPI {
 
-    // Methods using coroutines
+    /** Fetches all configured geofences (suspend variant). */
     suspend fun listGeofences(): Pair<GeofencesResponse?, NetworkingError?> {
         val endpoint = GeocomplianceEndpoints.ListGeofences
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<GeofencesResponse>(data) }, error)
     }
 
+    /**
+     * Fetches the geo-compliance status for the given account (suspend variant).
+     *
+     * @param accountId The account to evaluate.
+     */
     suspend fun getAccountGeoComplianceStatus(accountId: String): Pair<GeoComplianceStatusResponse?, NetworkingError?> {
         val endpoint = GeocomplianceEndpoints.AccountGeoCompliance(accountId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<GeoComplianceStatusResponse>(data) }, error)
     }
 
-    // Methods using callbacks
+    /** Fetches all configured geofences (callback variant). */
     fun listGeofences(completionHandler: (GeofencesResponse?, NetworkingError?) -> Unit) {
         val endpoint = GeocomplianceEndpoints.ListGeofences
 
@@ -27,6 +33,12 @@ object GeocomplianceAPI {
         }
     }
 
+    /**
+     * Fetches the geo-compliance status for the given account (callback variant).
+     *
+     * @param accountId The account to evaluate.
+     * @param completionHandler Called with the status response or a networking error.
+     */
     fun getAccountGeoComplianceStatus(
         accountId: String,
         completionHandler: (GeoComplianceStatusResponse?, NetworkingError?) -> Unit
@@ -38,4 +50,3 @@ object GeocomplianceAPI {
         }
     }
 }
-

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceEndpoints.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceEndpoints.kt
@@ -3,8 +3,11 @@ package com.framepayments.frameonboarding.networking.geocompliance
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/** Routing definitions for the Frame geo-compliance API endpoints. */
 sealed class GeocomplianceEndpoints : FrameNetworkingEndpoints {
+    /** Fetches all geofences configured for the merchant account. */
     data object ListGeofences : GeocomplianceEndpoints()
+    /** Fetches the geo-compliance status for a specific account. */
     data class AccountGeoCompliance(val accountId: String) : GeocomplianceEndpoints()
 
     override val endpointURL: String
@@ -19,4 +22,3 @@ sealed class GeocomplianceEndpoints : FrameNetworkingEndpoints {
     override val queryItems: List<QueryItem>?
         get() = null
 }
-

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceObjects.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceObjects.kt
@@ -2,26 +2,51 @@ package com.framepayments.frameonboarding.networking.geocompliance
 
 import com.google.gson.annotations.SerializedName
 
+/** Shape type of a geographic compliance fence. */
 enum class GeofenceType {
+    /** A polygonal fence defined by a set of lat/lng vertices. */
     @SerializedName("polygon") POLYGON,
+    /** A circular fence defined by a center point and radius. */
     @SerializedName("circle") CIRCLE
 }
 
+/** The device location event that fires a geofence rule. */
 enum class GeofenceRuleTrigger {
+    /** Fired when the device enters the fence. */
     @SerializedName("enter") ENTER,
+    /** Fired when the device exits the fence. */
     @SerializedName("exit") EXIT,
+    /** Fired when the device dwells inside the fence. */
     @SerializedName("dwell") DWELL
 }
 
+/** The action taken when a [GeofenceRule] is triggered. */
 enum class GeofenceRuleActionType {
+    /** Block the transaction when the rule fires. */
     @SerializedName("block_transaction") BLOCK_TRANSACTION
 }
 
+/**
+ * A single rule that pairs a trigger event with a resulting action for a geofence.
+ *
+ * @property triggerOn The device location event that fires the rule.
+ * @property actionType The action applied when the rule fires.
+ */
 data class GeofenceRule(
     @SerializedName("trigger_on") val triggerOn: GeofenceRuleTrigger?,
     @SerializedName("action_type") val actionType: GeofenceRuleActionType?
 )
 
+/**
+ * A geographic compliance fence configured on the Frame platform.
+ *
+ * @property id Unique identifier for this geofence.
+ * @property geofenceObject The API object type string (always `"geofence"`).
+ * @property name Human-readable name for the fence.
+ * @property geofenceType Whether the fence is a [GeofenceType.POLYGON] or [GeofenceType.CIRCLE].
+ * @property active Whether the fence is currently enforced.
+ * @property geofenceRules Rules that fire when device location intersects this fence.
+ */
 data class Geofence(
     val id: String?,
     @SerializedName("object") val geofenceObject: String?,
@@ -30,4 +55,3 @@ data class Geofence(
     val active: Boolean?,
     @SerializedName("geofence_rules") val geofenceRules: List<GeofenceRule>?
 )
-

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceResponses.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/geocompliance/GeocomplianceResponses.kt
@@ -2,27 +2,55 @@ package com.framepayments.frameonboarding.networking.geocompliance
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Response envelope for the list-geofences endpoint.
+ *
+ * @property data The list of geofences configured for the account.
+ */
 data class GeofencesResponse(
     val data: List<Geofence>?
 )
 
+/** The geo-compliance status for an account. */
 enum class GeoComplianceStatus {
+    /** The account is in a permitted location. */
     @SerializedName("clear") CLEAR,
+    /** The account is in a blocked location. */
     @SerializedName("blocked") BLOCKED,
+    /** The account's location could not be determined. */
     @SerializedName("unknown") UNKNOWN
 }
 
+/** The reason an account's geo-compliance check returned [GeoComplianceStatus.BLOCKED]. */
 enum class GeoComplianceBlockReason {
+    /** The device is in a restricted geographic territory. */
     @SerializedName("restricted_territory") RESTRICTED_TERRITORY,
+    /** A VPN was detected that masks the device's real location. */
     @SerializedName("vpn_detected") VPN_DETECTED,
+    /** Location data was unavailable or not granted. */
     @SerializedName("no_location_data") NO_LOCATION_DATA
 }
 
+/**
+ * A brief summary of the geofence involved in a geo-compliance evaluation.
+ *
+ * @property id Unique identifier of the matched geofence.
+ * @property name Human-readable name of the matched geofence.
+ */
 data class GeoComplianceGeofenceSummary(
     val id: String?,
     val name: String?
 )
 
+/**
+ * Full geo-compliance status for an account.
+ *
+ * @property status The compliance verdict for the account's current location.
+ * @property reason The reason for a [GeoComplianceStatus.BLOCKED] result, or null if clear.
+ * @property geofence The geofence that triggered the block, or null if not applicable.
+ * @property sonarSessionId The Sonar session used to collect location data.
+ * @property evaluatedAt Unix timestamp of when the compliance check was performed.
+ */
 data class GeoComplianceStatusResponse(
     val status: GeoComplianceStatus?,
     val reason: GeoComplianceBlockReason?,
@@ -30,4 +58,3 @@ data class GeoComplianceStatusResponse(
     @SerializedName("sonar_session_id") val sonarSessionId: String?,
     @SerializedName("evaluated_at") val evaluatedAt: Int?
 )
-

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationAPI.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationAPI.kt
@@ -3,12 +3,19 @@ package com.framepayments.frameonboarding.networking.phoneotpverification
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/** API methods for creating and confirming phone OTP verifications. */
 object PhoneOTPVerificationAPI {
 
     private suspend fun confirmRequestBody(code: String?): Any =
         if (code == null) emptyMap<String, String>() else PhoneOTPVerificationRequests.Confirm(code)
 
-    // Coroutine methods
+    /**
+     * Creates a phone verification for the given account (suspend variant).
+     *
+     * @param accountId The account to associate the verification with.
+     * @param phoneNumber Customer phone number in E.164 format.
+     * @param dateOfBirth Customer date of birth in YYYY-MM-DD format.
+     */
     suspend fun createVerification(
         accountId: String,
         phoneNumber: String,
@@ -23,6 +30,13 @@ object PhoneOTPVerificationAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<PhoneOTPVerificationCreateResponse>(it) }, error)
     }
 
+    /**
+     * Confirms a pending phone verification (suspend variant).
+     *
+     * @param accountId The account the verification belongs to.
+     * @param verificationId The verification ID returned by [createVerification].
+     * @param code OTP code entered by the customer; null for Prove-path (empty body).
+     */
     suspend fun confirmVerification(
         accountId: String,
         verificationId: String,
@@ -33,7 +47,14 @@ object PhoneOTPVerificationAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<PhoneOTPVerificationConfirmResponse>(it) }, error)
     }
 
-    // Callback methods
+    /**
+     * Creates a phone verification for the given account (callback variant).
+     *
+     * @param accountId The account to associate the verification with.
+     * @param phoneNumber Customer phone number in E.164 format.
+     * @param dateOfBirth Customer date of birth in YYYY-MM-DD format.
+     * @param completionHandler Called with the response or a networking error.
+     */
     fun createVerification(
         accountId: String,
         phoneNumber: String,
@@ -50,6 +71,14 @@ object PhoneOTPVerificationAPI {
         }
     }
 
+    /**
+     * Confirms a pending phone verification (callback variant).
+     *
+     * @param accountId The account the verification belongs to.
+     * @param verificationId The verification ID returned by [createVerification].
+     * @param code OTP code entered by the customer; null for Prove-path (empty body).
+     * @param completionHandler Called with the response or a networking error.
+     */
     fun confirmVerification(
         accountId: String,
         verificationId: String,

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationEndpoints.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationEndpoints.kt
@@ -2,8 +2,11 @@ package com.framepayments.frameonboarding.networking.phoneotpverification
 
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 
+/** Routing definitions for the phone OTP verification API endpoints. */
 sealed class PhoneOTPVerificationEndpoints : FrameNetworkingEndpoints {
+    /** Creates a new phone verification for the given account. */
     data class Create(val accountId: String) : PhoneOTPVerificationEndpoints()
+    /** Confirms an existing phone verification with an OTP code. */
     data class Confirm(val accountId: String, val verificationId: String) : PhoneOTPVerificationEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationObjects.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationObjects.kt
@@ -2,6 +2,14 @@ package com.framepayments.frameonboarding.networking.phoneotpverification
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Response from the create-phone-verification endpoint.
+ *
+ * @property id Unique identifier for the verification attempt.
+ * @property type The verification type (e.g. `"phone"`).
+ * @property status Current status of the verification.
+ * @property proveAuthToken Auth token for the Prove mobile SDK; null when using the Twilio OTP path.
+ */
 data class PhoneOTPVerificationCreateResponse(
     val id: String?,
     val type: String?,
@@ -9,15 +17,33 @@ data class PhoneOTPVerificationCreateResponse(
     @SerializedName("prove_auth_token") val proveAuthToken: String?
 )
 
+/**
+ * Response from the confirm-phone-verification endpoint.
+ *
+ * @property id Unique identifier for the verification attempt.
+ * @property status Final status of the verification after confirmation.
+ * @property prefillStatus Prefill status from the Prove identity prefill, if applicable.
+ */
 data class PhoneOTPVerificationConfirmResponse(
     val id: String?,
     val status: String?,
     @SerializedName("prefill_status") val prefillStatus: String? = null
 )
 
+/**
+ * Error wrapper returned by the phone verification endpoint on validation failure.
+ *
+ * @property error Structured error detail from the Frame API.
+ */
 data class PhoneOTPVerificationError(
     val error: ErrorDetail? = null
 ) {
+    /**
+     * Structured error detail from the Frame API.
+     *
+     * @property type Machine-readable error type string.
+     * @property message Human-readable error message.
+     */
     data class ErrorDetail(
         val type: String? = null,
         val message: String? = null

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationRequests.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/networking/phoneotpverification/PhoneOTPVerificationRequests.kt
@@ -2,9 +2,14 @@ package com.framepayments.frameonboarding.networking.phoneotpverification
 
 import com.google.gson.annotations.SerializedName
 
+/** Request body types for the phone OTP verification endpoints. */
 object PhoneOTPVerificationRequests {
     /**
-     * Create phone verification request. dateOfBirth must be YYYY-MM-DD.
+     * Create phone verification request. `dateOfBirth` must be in `YYYY-MM-DD` format.
+     *
+     * @property type Verification type; always `"phone"`.
+     * @property phoneNumber Customer phone number in E.164 format.
+     * @property dateOfBirth Customer date of birth in YYYY-MM-DD format.
      */
     data class Create(
         val type: String = "phone",
@@ -13,7 +18,9 @@ object PhoneOTPVerificationRequests {
     )
 
     /**
-     * Confirm OTP code (Twilio path). Omit code for Prove path (empty body).
+     * Confirm OTP code (Twilio path). Omit `code` for the Prove path (sends an empty body).
+     *
+     * @property code The OTP code entered by the customer.
      */
     data class Confirm(
         val code: String?

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/plaid/PlaidLinkService.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/plaid/PlaidLinkService.kt
@@ -9,9 +9,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
+/** Outcome of a Plaid Link bank account connection flow. */
 sealed class PlaidLinkResult {
-    data class Success(val paymentMethod: FrameObjects.PaymentMethod) : PlaidLinkResult()
-    data class Failure(val error: NetworkingError?) : PlaidLinkResult()
+    /** The bank account was successfully connected and a PaymentMethod was created. */
+    data class Success(
+        /** The PaymentMethod created for the connected bank account. */
+        val paymentMethod: FrameObjects.PaymentMethod
+    ) : PlaidLinkResult()
+    /** The connection failed due to a networking or API error. */
+    data class Failure(
+        /** The underlying error, or null if the cause is unknown. */
+        val error: NetworkingError?
+    ) : PlaidLinkResult()
+    /** The customer dismissed the Plaid Link UI without completing. */
     data object Dismissed : PlaidLinkResult()
 }
 
@@ -25,7 +35,10 @@ sealed class PlaidLinkResult {
  *  3. On Plaid success, call [connectBankAccount]. On dismiss/cancel, call [onDismissed].
  *  4. Observe [isConnecting] for loading state and [result] for final outcome.
  */
-class PlaidLinkService(val accountId: String) {
+class PlaidLinkService(
+    /** The Frame account ID that will own the connected bank account. */
+    val accountId: String
+) {
 
     private val _linkToken = MutableStateFlow<String?>(null)
     val linkToken: StateFlow<String?> = _linkToken.asStateFlow()
@@ -36,6 +49,7 @@ class PlaidLinkService(val accountId: String) {
     private val _result = MutableStateFlow<PlaidLinkResult?>(null)
     val result: StateFlow<PlaidLinkResult?> = _result.asStateFlow()
 
+    /** Fetches a Plaid Link token from the Frame API and stores it in [linkToken]. No-op if already loading or a token exists. */
     suspend fun fetchLinkToken() {
         if (_isConnecting.value || _linkToken.value != null) return
         _isConnecting.value = true
@@ -49,10 +63,12 @@ class PlaidLinkService(val accountId: String) {
         }
     }
 
+    /** Clears the stored link token so a [LaunchedEffect] won't re-fire after the Plaid UI is launched. */
     fun clearLinkToken() {
         _linkToken.value = null
     }
 
+    /** Exchanges the Plaid public token for a Frame PaymentMethod and stores the result in [result]. */
     suspend fun connectBankAccount(
         publicToken: String,
         plaidAccountId: String,
@@ -76,11 +92,13 @@ class PlaidLinkService(val accountId: String) {
         }
     }
 
+    /** Records a [PlaidLinkResult.Dismissed] result when the customer cancels the Plaid Link UI. */
     fun onDismissed() {
         _isConnecting.value = false
         _result.value = PlaidLinkResult.Dismissed
     }
 
+    /** Clears [result] so the UI can reset state after handling the outcome. */
     fun clearResult() {
         _result.value = null
     }

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/prove/ProveAuthService.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/prove/ProveAuthService.kt
@@ -19,18 +19,36 @@ typealias ProveOtpProvider = suspend () -> String?
 // Closure invoked when Prove auth completes. Receives accountId and verificationId from the service.
 typealias ProveConfirmHandler = suspend (String, String) -> Unit
 
-// User information returned after successful Prove authentication and backend verify.
+/**
+ * User information returned after successful Prove authentication and backend verify.
+ *
+ * @property firstName Customer's first name as returned by Prove identity prefill.
+ * @property lastName Customer's last name as returned by Prove identity prefill.
+ */
 data class ProveUserInfo(
     val firstName: String,
     val lastName: String
 )
 
-// Typed errors for ProveAuthService for use by the UI layer.
+/** Typed errors from [ProveAuthService] for use by the UI layer. */
 sealed class ProveAuthServiceError : Exception() {
-    data class VerifyFailed(val underlying: Throwable) : ProveAuthServiceError()
+    /** The Prove backend verify call failed. */
+    data class VerifyFailed(
+        /** The underlying exception from the verify call. */
+        val underlying: Throwable
+    ) : ProveAuthServiceError()
+    /** The customer cancelled the Prove auth flow. */
     data object Cancelled : ProveAuthServiceError()
-    data class SdkError(val underlying: Throwable) : ProveAuthServiceError()
-    data class Unknown(val underlying: Throwable) : ProveAuthServiceError()
+    /** The Prove SDK itself threw an error. */
+    data class SdkError(
+        /** The underlying exception from the Prove SDK. */
+        val underlying: Throwable
+    ) : ProveAuthServiceError()
+    /** An unknown error occurred. */
+    data class Unknown(
+        /** The underlying exception. */
+        val underlying: Throwable
+    ) : ProveAuthServiceError()
 
     override val message: String?
         get() = when (this) {

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/ContinueButton.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/ContinueButton.kt
@@ -21,8 +21,27 @@ import com.framepayments.framesdk_ui.theme.LocalFrameTheme
  * While [isLoading] is true the label is replaced with a circular spinner and presses are
  * blocked; while !`enabled` the button is disabled and a stroke is drawn around it (matches iOS).
  */
-enum class ContinueButtonStyle { PRIMARY, SECONDARY }
+/** Visual style variant for [ContinueButton]. */
+enum class ContinueButtonStyle {
+    /** Filled primary button. */
+    PRIMARY,
+    /** Outlined secondary button. */
+    SECONDARY
+}
 
+/**
+ * Primary action button shared by checkout and onboarding. 1:1 port of iOS `ContinueButton`.
+ *
+ * While [isLoading] is true the label is replaced with a circular spinner and presses are
+ * blocked; while `!enabled` the button is disabled and a stroke is drawn around it.
+ *
+ * @param text Button label text.
+ * @param style [ContinueButtonStyle.PRIMARY] (filled) or [ContinueButtonStyle.SECONDARY] (outlined).
+ * @param enabled Whether the button accepts presses.
+ * @param isLoading When true, shows a spinner and blocks presses.
+ * @param modifier Layout modifier.
+ * @param onClick Called when the button is tapped.
+ */
 @Composable
 fun ContinueButton(
     text: String = "Continue",

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/PaymentCardForm.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/PaymentCardForm.kt
@@ -16,6 +16,19 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.framepayments.framesdk_ui.theme.LocalFrameTheme
 
+/**
+ * A card number, expiry, and CVC input form for entering payment card details manually.
+ *
+ * @param cardNumber Current card number value (digits only, no spaces stored internally).
+ * @param onCardNumberChange Called when the card number changes.
+ * @param expiryMonth Two-digit expiry month.
+ * @param expiryYear Two-digit expiry year.
+ * @param onExpiryChange Called when either expiry component changes.
+ * @param cvc Current CVC value.
+ * @param onCvcChange Called when the CVC changes.
+ * @param headerTitle Label displayed above the form when [showHeader] is true.
+ * @param showHeader Whether to show the section header label.
+ */
 @Composable
 fun PaymentCardForm(
     cardNumber: String,

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/PaymentDivider.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/PaymentDivider.kt
@@ -12,8 +12,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.framepayments.framesdk_ui.theme.LocalFrameTheme
 
-/// Mirrors the "Or" divider used in the checkout layout to separate wallet payment options
-/// (Google Pay) from the card form. Drop between the wallet button and the card section.
+/**
+ * Horizontal "Or" divider used to separate wallet payment options (Google Pay) from the card form.
+ *
+ * @param modifier Layout modifier.
+ * @param label Text displayed between the two divider lines (default: "Or").
+ */
 @Composable
 fun PaymentDivider(
     modifier: Modifier = Modifier,

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/TermsOfServiceView.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/TermsOfServiceView.kt
@@ -23,6 +23,16 @@ import com.framepayments.framesdk_ui.theme.LocalFrameTheme
 import com.framepayments.framesdk_ui.theme.FrameTheme
 import com.framepayments.framesdk_ui.theme.FrameThemePreviews
 
+/**
+ * Legal consent text linking to Frame's Privacy Policy and Terms of Service.
+ *
+ * @param privacyPolicyUrl URL for the Privacy Policy link.
+ * @param termsOfServiceUrl URL for the Terms of Service link.
+ * @param textColor Color for the non-link body text.
+ * @param linkColor Color for the tappable link text.
+ * @param textAlign Alignment of the legal text.
+ * @param padded When true, wraps the view in a rounded surface card.
+ */
 @Composable
 fun TermsOfServiceView(
     privacyPolicyUrl: String = "https://framepayments.com/privacy",

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/Utilities.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/reusable/Utilities.kt
@@ -3,6 +3,12 @@ package com.framepayments.frameonboarding.reusable
 import androidx.annotation.DrawableRes
 import com.framepayments.frameonboarding.R
 
+/**
+ * Returns the drawable resource id for the card brand icon matching [brand].
+ *
+ * @param brand Card brand string (e.g. `"visa"`, `"mastercard"`, `"amex"`). Case-insensitive.
+ * @return A `@DrawableRes` id for the brand icon, or a generic card icon for unknown brands.
+ */
 @DrawableRes
 fun cardBrandIcon(brand: String): Int {
     return when (brand.uppercase()) {

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/validation/DateOfBirthFormatter.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/validation/DateOfBirthFormatter.kt
@@ -5,6 +5,15 @@ package com.framepayments.frameonboarding.validation
  * Returns an empty string if any component is empty. 1:1 port of iOS DateOfBirthFormatter.
  */
 object DateOfBirthFormatter {
+    /**
+     * Assembles a zero-padded ISO 8601 date string from separate year, month, and day components.
+     *
+     * @param year 4-digit year (e.g. "1990").
+     * @param month 1- or 2-digit month; single digits are zero-padded (e.g. "3" → "03").
+     * @param day 1- or 2-digit day; single digits are zero-padded (e.g. "5" → "05").
+     * @return An ISO 8601 string in the form "YYYY-MM-DD", or an empty string if any component
+     *   is empty.
+     */
     fun format(year: String, month: String, day: String): String {
         if (year.isEmpty() || month.isEmpty() || day.isEmpty()) return ""
         val paddedYear = if (year.length >= 4) year else "0".repeat(4 - year.length) + year

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/validation/OnboardingValidators.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/validation/OnboardingValidators.kt
@@ -18,9 +18,22 @@ object OnboardingValidators {
 
     private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
 
+    /**
+     * Validates that [value] is non-blank.
+     *
+     * @param value The string to check.
+     * @param fieldName Human-readable field name used in the error message (e.g. "First name").
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateNonEmpty(value: String, fieldName: String): String? =
         if (value.trim().isEmpty()) "$fieldName is required" else null
 
+    /**
+     * Validates that [value] contains at least a first and last name separated by whitespace.
+     *
+     * @param value Full name string entered by the customer.
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateFullName(value: String): String? {
         val trimmed = value.trim()
         if (trimmed.isEmpty()) return "Full name is required"
@@ -28,18 +41,36 @@ object OnboardingValidators {
         return if (parts.size >= 2) null else "Enter first and last name"
     }
 
+    /**
+     * Validates that [value] is a non-empty, well-formed email address.
+     *
+     * @param value Email string entered by the customer.
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateEmail(value: String): String? {
         val trimmed = value.trim()
         if (trimmed.isEmpty()) return "Email is required"
         return if (EMAIL_REGEX.matches(trimmed)) null else "Enter a valid email address"
     }
 
+    /**
+     * Validates that [value] is a 5-digit US zip code.
+     *
+     * @param value Zip code string entered by the customer.
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateZipUS(value: String): String? {
         if (value.isEmpty()) return "Zip code is required"
         val isValid = value.length == 5 && value.all { it.isDigit() }
         return if (isValid) null else "Enter a 5-digit zip code"
     }
 
+    /**
+     * Validates Evervault card data using its potential-validity check.
+     *
+     * @param data Card data snapshot from the Evervault input, or null if no data has been entered.
+     * @return Null if the card is potentially valid, a localized error string otherwise.
+     */
     fun validateCard(data: PaymentCardData?): String? {
         // Evervault's isPotentiallyValid returns true for an empty card; require a
         // non-empty PAN as well (matches FrameCheckoutViewModel.isCardValid).
@@ -48,6 +79,13 @@ object OnboardingValidators {
         return if (data.isPotentiallyValid) null else "Enter valid card details"
     }
 
+    /**
+     * Validates a Card expiration date, ensuring the month is in range and the card has not expired.
+     *
+     * @param month Expiration month as a 1- or 2-digit string.
+     * @param year Expiration year as a 2- or 4-digit string.
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateCardExpiry(month: String, year: String): String? {
         val m = month.toIntOrNull() ?: return "Invalid expiration month"
         if (m !in 1..12) return "Invalid expiration month"
@@ -62,12 +100,24 @@ object OnboardingValidators {
         return null
     }
 
+    /**
+     * Validates that [value] is exactly 4 ASCII digits (last four of SSN).
+     *
+     * @param value SSN last-four digits entered by the customer.
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateSSNLast4(value: String): String? {
         if (value.isEmpty()) return "SSN is required"
         val isValid = value.length == 4 && value.all { it.isDigit() }
         return if (isValid) null else "Enter last 4 digits of SSN"
     }
 
+    /**
+     * Validates that [value] is a 9-digit US ABA routing number with a valid checksum.
+     *
+     * @param value Routing number string entered by the customer.
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateRoutingNumberUS(value: String): String? {
         if (value.isEmpty()) return "Routing number is required"
         if (value.length != 9 || !value.all { it.isDigit() }) {
@@ -80,12 +130,33 @@ object OnboardingValidators {
         return if (checksum == 0) null else "Enter a valid routing number"
     }
 
+    /**
+     * Validates that [value] is a numeric US bank account number within the accepted length range.
+     *
+     * @param value Account number string entered by the customer.
+     * @param min Minimum acceptable length (default: 4).
+     * @param max Maximum acceptable length (default: 17).
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateAccountNumberUS(value: String, min: Int = 4, max: Int = 17): String? {
         if (value.isEmpty()) return "Account number is required"
         val isValid = value.all { it.isDigit() } && value.length in min..max
         return if (isValid) null else "Enter a valid account number"
     }
 
+    /**
+     * Validates a date-of-birth split into year, month, and day components.
+     *
+     * Checks that the date is a real calendar date and that the resulting age falls within
+     * [minAge] and [maxAge] years from today.
+     *
+     * @param year 4-digit year string.
+     * @param month 1- or 2-digit month string (1–12).
+     * @param day 1- or 2-digit day string.
+     * @param minAge Minimum required age in years (default: 18).
+     * @param maxAge Maximum accepted age in years (default: 120).
+     * @return Null if valid, a localized error string otherwise.
+     */
     fun validateDateOfBirth(
         year: String,
         month: String,
@@ -135,6 +206,15 @@ object OnboardingValidators {
         "SG" to Regex("^\\d{6}$")
     )
 
+    /**
+     * Validates [value] against the postal code pattern for the given [countryCode].
+     *
+     * Countries without a known pattern are considered valid (returns null).
+     *
+     * @param value Postal code string entered by the customer.
+     * @param countryCode ISO 3166-1 alpha-2 country code (case-insensitive).
+     * @return Null if valid or if the country has no known pattern, a localized error string otherwise.
+     */
     fun validatePostalCode(value: String, countryCode: String): String? {
         val trimmed = value.trim()
         if (trimmed.isEmpty()) return "Postal code is required"
@@ -144,6 +224,15 @@ object OnboardingValidators {
 
     private val phoneUtil: PhoneNumberUtil by lazy { PhoneNumberUtil.getInstance() }
 
+    /**
+     * Validates that [raw] is a possible phone number for the given [regionCode] using
+     * libphonenumber's "isPossibleNumber" check (less strict than full validation, matching
+     * iOS PhoneNumberKit semantics).
+     *
+     * @param raw Raw phone number string as entered by the customer (without dial code prefix).
+     * @param regionCode ISO 3166-1 alpha-2 region code used to parse the number (e.g. "US").
+     * @return Null if the number is possibly valid for the region, a localized error string otherwise.
+     */
     fun validatePhoneE164(raw: String, regionCode: String): String? {
         val trimmed = raw.trim()
         if (trimmed.isEmpty()) return "Phone number is required"

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/viewmodels/BankAccountFieldVM.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/viewmodels/BankAccountFieldVM.kt
@@ -11,34 +11,64 @@ import kotlinx.coroutines.flow.update
 
 /**
  * Per-screen view model for the bank account (ACH) form.
- * 1:1 port of iOS BankAccountViewModel.
  *
- * Constructed via `remember { }` in the composable — not an AAC ViewModel.
- * Account-type selection is intentionally NOT owned here (matches iOS, where it lives
- * outside BankAccountViewModel as @State on the parent screen).
+ * Constructed via `remember { }` in the composable — not an AAC ViewModel. Mirrors iOS
+ * `BankAccountViewModel`. Account-type selection is intentionally NOT owned here; it lives
+ * outside as `@State` on the parent screen.
+ *
+ * @param initial Initial [BankAccountDraft] pre-populating the form (default: empty draft).
  */
 class BankAccountFieldVM(initial: BankAccountDraft = BankAccountDraft()) {
 
-    enum class Field { ROUTING, ACCOUNT }
+    /** Identifies each input field in the bank account form. */
+    enum class Field {
+        /** ABA routing number field. */
+        ROUTING,
+        /** Bank account number field. */
+        ACCOUNT
+    }
 
     private val _draft = MutableStateFlow(initial)
+    /** Current bank account draft state; collect to drive the form UI. */
     val draft: StateFlow<BankAccountDraft> = _draft.asStateFlow()
 
     private val _errors = MutableStateFlow<Map<Field, String>>(emptyMap())
+    /** Current field-level validation errors keyed by [Field]. */
     val errors: StateFlow<Map<Field, String>> = _errors.asStateFlow()
 
+    /**
+     * Applies [transform] to the current [draft], replacing it with the result.
+     *
+     * @param transform Pure function that maps the current draft to an updated draft.
+     */
     fun updateDraft(transform: (BankAccountDraft) -> BankAccountDraft) {
         _draft.update(transform)
     }
 
+    /**
+     * Returns the current validation error message for [field], or null if the field is valid.
+     *
+     * @param field The field to query.
+     * @return Error string, or null.
+     */
     fun errorFor(field: Field): String? = _errors.value[field]
 
+    /**
+     * Clears the validation error for [field] if one is currently set.
+     *
+     * @param field The field whose error should be cleared.
+     */
     fun clearError(field: Field) {
         if (_errors.value.containsKey(field)) {
             _errors.update { it - field }
         }
     }
 
+    /**
+     * Validates the current [draft] and updates [errors] with any failures.
+     *
+     * @return True if all fields pass validation; false if any errors were found.
+     */
     fun validate(): Boolean {
         val next = mutableMapOf<Field, String>()
         OnboardingValidators.validateRoutingNumberUS(_draft.value.routingNumber)
@@ -49,7 +79,9 @@ class BankAccountFieldVM(initial: BankAccountDraft = BankAccountDraft()) {
         return next.isEmpty()
     }
 
+    /** Saver for use with `rememberSaveable` so bank account field state survives config change. */
     companion object {
+        /** [Saver] that persists routing number, account number, and account type across config changes. */
         val Saver: Saver<BankAccountFieldVM, Any> = listSaver(
             save = { vm ->
                 val d = vm._draft.value

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/viewmodels/BillingAddressFieldVM.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/viewmodels/BillingAddressFieldVM.kt
@@ -10,23 +10,45 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-enum class BillingAddressMode { US_ONLY, INTERNATIONAL }
+/**
+ * Controls the validation behavior and available fields in [BillingAddressFieldVM].
+ */
+enum class BillingAddressMode {
+    /** Pins the country to "US" and uses US 5-digit zip validation. */
+    US_ONLY,
+    /** Allows country selection and applies per-country postal code validation. */
+    INTERNATIONAL
+}
 
 /**
  * Per-screen view model for the billing address form.
- * 1:1 port of iOS BillingAddressViewModel.
  *
- * In [BillingAddressMode.US_ONLY] mode the country is pinned to "US" and zip uses
- * the US 5-digit validator. In [BillingAddressMode.INTERNATIONAL] mode the country
- * is selectable and postal code validation uses [OnboardingValidators.validatePostalCode]
- * for the active country.
+ * Mirrors iOS `BillingAddressViewModel`. In [BillingAddressMode.US_ONLY] mode the country is
+ * pinned to "US" and zip uses the US 5-digit validator. In [BillingAddressMode.INTERNATIONAL]
+ * mode the country is selectable and postal code validation uses
+ * [OnboardingValidators.validatePostalCode] for the active country.
+ *
+ * @param initial Pre-populated billing address (country defaults to "US" if blank).
+ * @param mode Validation behavior and country-field visibility mode.
  */
 class BillingAddressFieldVM(
     initial: FrameObjects.BillingAddress,
     val mode: BillingAddressMode
 ) {
 
-    enum class Field { LINE1, CITY, STATE, POSTAL, COUNTRY }
+    /** Identifies each input field in the billing address form. */
+    enum class Field {
+        /** Address line 1 field. */
+        LINE1,
+        /** City field. */
+        CITY,
+        /** State/province field. */
+        STATE,
+        /** Postal/zip code field. */
+        POSTAL,
+        /** Country selection field (only used in [BillingAddressMode.INTERNATIONAL] mode). */
+        COUNTRY
+    }
 
     private val _address = MutableStateFlow(
         when (mode) {
@@ -35,17 +57,35 @@ class BillingAddressFieldVM(
                 if (initial.country.isNullOrBlank()) initial.copy(country = "US") else initial
         }
     )
+    /** Current billing address state; collect to drive the form UI. */
     val address: StateFlow<FrameObjects.BillingAddress> = _address.asStateFlow()
 
     private val _errors = MutableStateFlow<Map<Field, String>>(emptyMap())
+    /** Current field-level validation errors keyed by [Field]. */
     val errors: StateFlow<Map<Field, String>> = _errors.asStateFlow()
 
+    /**
+     * Applies [transform] to the current [address], replacing it with the result.
+     *
+     * @param transform Pure function that maps the current address to an updated address.
+     */
     fun updateAddress(transform: (FrameObjects.BillingAddress) -> FrameObjects.BillingAddress) {
         _address.update(transform)
     }
 
+    /**
+     * Returns the current validation error message for [field], or null if the field is valid.
+     *
+     * @param field The field to query.
+     * @return Error string, or null.
+     */
     fun errorFor(field: Field): String? = _errors.value[field]
 
+    /**
+     * Clears the validation error for [field] if one is currently set.
+     *
+     * @param field The field whose error should be cleared.
+     */
     fun clearError(field: Field) {
         if (_errors.value.containsKey(field)) {
             _errors.update { it - field }
@@ -71,6 +111,7 @@ class BillingAddressFieldVM(
         }
     }
 
+    /** Factory methods for constructing a [BillingAddressFieldVM] and its state [Saver]. */
     companion object {
         /** Saver for use with `rememberSaveable` so user typing survives config change. */
         fun Saver(mode: BillingAddressMode): Saver<BillingAddressFieldVM, Any> =
@@ -102,6 +143,11 @@ class BillingAddressFieldVM(
             )
     }
 
+    /**
+     * Validates the current [address] according to the active [mode] and updates [errors].
+     *
+     * @return True if all required fields pass validation; false if any errors were found.
+     */
     fun validate(): Boolean {
         val next = mutableMapOf<Field, String>()
         val addr = _address.value

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/viewmodels/CustomerInformationFieldVM.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/viewmodels/CustomerInformationFieldVM.kt
@@ -13,28 +13,50 @@ import kotlinx.coroutines.flow.update
 
 /**
  * Per-screen view model for the customer information form (first/last name, email, phone, DOB, SSN).
- * 1:1 port of iOS CustomerInformationViewModel.
  *
- * Stores DOB as ISO "YYYY-MM-DD" inside [identity]; the view layer manages three
- * local Compose state strings for month/day/year and syncs them via DateOfBirthFormatter.
+ * Mirrors iOS `CustomerInformationViewModel`. Stores DOB as ISO "YYYY-MM-DD" inside [identity];
+ * the view layer manages three local Compose state strings for month/day/year and syncs them via
+ * [com.framepayments.frameonboarding.validation.DateOfBirthFormatter].
+ *
+ * @param initialIdentity Pre-populated identity request (all fields default to empty strings).
+ * @param initialPhoneCountry Pre-selected phone country (defaults to the device locale country).
  */
 class CustomerInformationFieldVM(
     initialIdentity: CustomerIdentityRequests.CreateCustomerIdentityRequest,
     initialPhoneCountry: PhoneCountrySelection = PhoneCountrySelection.default
 ) {
 
+    /** Identifies each input field in the customer information form. */
     enum class Field {
-        FIRST_NAME, LAST_NAME, EMAIL, PHONE, BIRTH_MONTH, BIRTH_DAY, BIRTH_YEAR, SSN
+        /** First name field. */
+        FIRST_NAME,
+        /** Last name field. */
+        LAST_NAME,
+        /** Email address field. */
+        EMAIL,
+        /** Phone number field. */
+        PHONE,
+        /** Birth month field (1–2 digit numeric string). */
+        BIRTH_MONTH,
+        /** Birth day field (1–2 digit numeric string). */
+        BIRTH_DAY,
+        /** Birth year field (4-digit numeric string). */
+        BIRTH_YEAR,
+        /** Last four digits of SSN field. */
+        SSN
     }
 
     private val _identity = MutableStateFlow(initialIdentity)
+    /** Current identity request state; collect to drive the form UI. */
     val identity: StateFlow<CustomerIdentityRequests.CreateCustomerIdentityRequest> =
         _identity.asStateFlow()
 
     private val _phoneCountry = MutableStateFlow(initialPhoneCountry)
+    /** Currently selected phone country for dial-code prefix display and validation. */
     val phoneCountry: StateFlow<PhoneCountrySelection> = _phoneCountry.asStateFlow()
 
     private val _errors = MutableStateFlow<Map<Field, String>>(emptyMap())
+    /** Current field-level validation errors keyed by [Field]. */
     val errors: StateFlow<Map<Field, String>> = _errors.asStateFlow()
 
     /**
@@ -47,18 +69,39 @@ class CustomerInformationFieldVM(
         return errs[Field.BIRTH_MONTH] ?: errs[Field.BIRTH_DAY] ?: errs[Field.BIRTH_YEAR]
     }
 
+    /**
+     * Applies [transform] to the current [identity] request, replacing it with the result.
+     *
+     * @param transform Pure function that maps the current identity request to an updated one.
+     */
     fun updateIdentity(
         transform: (CustomerIdentityRequests.CreateCustomerIdentityRequest) -> CustomerIdentityRequests.CreateCustomerIdentityRequest
     ) {
         _identity.update(transform)
     }
 
+    /**
+     * Updates the selected phone country to [selection].
+     *
+     * @param selection The [PhoneCountrySelection] chosen by the customer.
+     */
     fun setPhoneCountry(selection: PhoneCountrySelection) {
         _phoneCountry.value = selection
     }
 
+    /**
+     * Returns the current validation error message for [field], or null if the field is valid.
+     *
+     * @param field The field to query.
+     * @return Error string, or null.
+     */
     fun errorFor(field: Field): String? = _errors.value[field]
 
+    /**
+     * Clears the validation error for [field] if one is currently set.
+     *
+     * @param field The field whose error should be cleared.
+     */
     fun clearError(field: Field) {
         if (_errors.value.containsKey(field)) {
             _errors.update { it - field }
@@ -78,6 +121,11 @@ class CustomerInformationFieldVM(
         }
     }
 
+    /**
+     * Validates the current [identity] form and updates [errors] with any failures.
+     *
+     * @return True if all fields pass validation; false if any errors were found.
+     */
     fun validate(): Boolean {
         val next = mutableMapOf<Field, String>()
         val id = _identity.value
@@ -110,6 +158,7 @@ class CustomerInformationFieldVM(
         return next.isEmpty()
     }
 
+    /** Saver factory for use with `rememberSaveable` so customer information survives config change. */
     companion object {
         /** Saver so user typing survives config change (rotation, dark-mode toggle, etc.). */
         val Saver: Saver<CustomerInformationFieldVM, Any> = listSaver(

--- a/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/views/OnboardingContainerView.kt
+++ b/FrameSDK-Onboarding/src/main/java/com/framepayments/frameonboarding/views/OnboardingContainerView.kt
@@ -23,6 +23,18 @@ import com.framepayments.frameonboarding.viewmodels.FrameOnboardingViewModel
 import com.framepayments.framesdk_ui.theme.FrameTheme
 import com.framepayments.framesdk_ui.theme.FrameThemePreviews
 
+/**
+ * Root composable for the Frame onboarding flow.
+ *
+ * Instantiates a [FrameOnboardingViewModel], renders a progress indicator, and routes the
+ * customer through the capability-driven step sequence defined by [OnboardingConfig].  The
+ * active [FrameTheme] is provided to all child composables automatically.
+ *
+ * @param config Onboarding configuration specifying the account, required capabilities, and
+ *   optional theme overrides.
+ * @param onResult Callback invoked with the terminal [OnboardingResult] when the flow
+ *   completes, is cancelled, or fails.
+ */
 @Composable
 fun OnboardingContainerView(
     config: OnboardingConfig,

--- a/FrameSDK-UI/build.gradle.kts
+++ b/FrameSDK-UI/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     kotlin("android") version "2.2.10"
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.10"
     id("com.vanniktech.maven.publish")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.dokka)
 }
 
 android {
@@ -99,6 +101,16 @@ mavenPublishing {
 
     publishToMavenCentral(automaticRelease = true)
     signAllPublications()
+}
+
+detekt {
+    config.setFrom(rootProject.file("config/detekt/detekt.yml"))
+    source.setFrom("src/main/java")
+    autoCorrect = false
+}
+
+tasks.named("dokkaHtml") {
+    outputs.upToDateWhen { false }
 }
 
 // CI: print per-test pass/fail names instead of the silent default. Helps surface

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/AddressMode.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/AddressMode.kt
@@ -1,7 +1,13 @@
 package com.framepayments.framesdk_ui
 
+/** Controls whether billing address fields are shown and required in [FrameCheckoutView]. */
 enum class AddressMode {
+    /** Address fields are shown and the customer must complete them before paying. */
     REQUIRED,
+
+    /** Address fields are shown but the customer may leave them blank. */
     OPTIONAL,
+
+    /** Address fields are hidden entirely. */
     HIDDEN
 }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/CurrencyFormatter.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/CurrencyFormatter.kt
@@ -3,9 +3,16 @@ package com.framepayments.framesdk_ui
 import java.text.NumberFormat
 import java.util.Locale
 
+/** Formats integer cent amounts as USD currency strings for display in Frame UI components. */
 object CurrencyFormatter {
     private val nf = NumberFormat.getCurrencyInstance(Locale.US)
 
+    /**
+     * Converts a cent-denominated integer to a formatted USD currency string.
+     *
+     * @param cents Amount in US cents (e.g. `2500` → `"$25.00"`).
+     * @return Formatted currency string suitable for display.
+     */
     fun convertCentsToCurrencyString(cents: Int): String {
         return nf.format(cents / 100.0)
     }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCartAppearance.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCartAppearance.kt
@@ -3,8 +3,30 @@ package com.framepayments.framesdk_ui
 import android.graphics.Typeface
 
 /**
- * Appearance customization for [FrameCartView], aligned with iOS FrameCartView options.
+ * Appearance customization for [FrameCartView], aligned with iOS `FrameCartView` options.
  * All properties are optional; only set values you want to override from defaults.
+ *
+ * @property backgroundColor ARGB background color of the cart container. `null` uses the default.
+ * @property cartTitle Override title text. Defaults to `"Your Cart"`.
+ * @property cartTitleColor ARGB text color for the cart title. `null` uses the default.
+ * @property cartTitleSizeSp Font size in SP for the cart title. `null` uses the default.
+ * @property cartTitleTypeface Typeface style constant (e.g. [Typeface.BOLD]) for the cart title.
+ * @property subtitle Optional subtitle displayed below the cart title. Hidden when `null`.
+ * @property subtitleColor ARGB text color for the subtitle. `null` uses the default.
+ * @property subtitleSizeSp Font size in SP for the subtitle. `null` uses the default.
+ * @property cartItemColor ARGB text color for each line-item row. `null` uses the default.
+ * @property cartItemSizeSp Font size in SP for line-item text. `null` uses the default.
+ * @property cartItemBackgroundColor ARGB background color for each line-item row. `null` uses the default.
+ * @property cartItemHeightPx Fixed height in pixels for each line-item row. `null` uses wrap-content.
+ * @property auxiliaryLabelColor ARGB text color for subtotal and shipping labels. `null` uses the default.
+ * @property auxiliaryLabelSizeSp Font size in SP for subtotal and shipping labels. `null` uses the default.
+ * @property totalColor ARGB text color for the total row. `null` uses the default.
+ * @property totalSizeSp Font size in SP for the total row. `null` uses the default.
+ * @property totalTypeface Typeface style constant for the total row. Defaults to [Typeface.BOLD].
+ * @property checkoutButtonTitle Override label for the checkout button. Defaults to `"Checkout"`.
+ * @property checkoutButtonBackgroundColor ARGB background color for the checkout button. `null` uses the theme primary.
+ * @property checkoutButtonTextColor ARGB text color for the checkout button. `null` uses the default.
+ * @property checkoutButtonTextSizeSp Font size in SP for the checkout button label. `null` uses the default.
  */
 data class FrameCartAppearance(
     val backgroundColor: Int? = null,

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCartItem.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCartItem.kt
@@ -1,5 +1,13 @@
 package com.framepayments.framesdk_ui
 
+/**
+ * A single line item displayed in [FrameCartView].
+ *
+ * @property id Unique identifier for this item.
+ * @property title Display name shown in the cart row.
+ * @property amountInCents Item price in US cents (e.g. `2500` = $25.00).
+ * @property imageUrl URL of the item's thumbnail image.
+ */
 data class FrameCartItem(
     val id: String,
     val title: String,

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCartView.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCartView.kt
@@ -16,6 +16,10 @@ import com.framepayments.framesdk_ui.theme.FrameTheme
 import com.framepayments.framesdk_ui.theme.toCartAppearance
 import com.framepayments.framesdk_ui.viewmodels.FrameCartViewModel
 
+/**
+ * Displays a scrollable list of cart items with subtotal, shipping, and total summaries, and
+ * a checkout button that invokes the merchant-supplied callback with the final total in cents.
+ */
 class FrameCartView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCheckoutView.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/FrameCheckoutView.kt
@@ -32,6 +32,11 @@ import com.framepayments.framesdk_ui.viewmodels.AvailableCountries
 import com.framepayments.framesdk_ui.viewmodels.FrameCheckoutViewModel
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
+/**
+ * Full-screen checkout surface that collects customer information, billing address, and card
+ * details, then creates a Transfer against the supplied account and reports the outcome via
+ * [onResult].
+ */
 class FrameCheckoutView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -44,6 +49,7 @@ class FrameCheckoutView @JvmOverloads constructor(
     )
     private val viewModel: FrameCheckoutViewModel
 
+    /** Callback invoked with the terminal [FrameResult] once the checkout completes, is cancelled, or fails. */
     var onResult: ((FrameResult) -> Unit)? = null
 
     /**

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/buttons/FrameGooglePayButton.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/buttons/FrameGooglePayButton.kt
@@ -81,31 +81,65 @@ class FrameGooglePayButton @JvmOverloads constructor(
      * Callers infer the resource type from the owner they passed in.
      */
     sealed class Owner {
-        data class Customer(val id: String) : Owner()
-        data class Account(val id: String) : Owner()
+        /** A customer-scoped owner; Google Pay charges produce a ChargeIntent. */
+        data class Customer(
+            /** The customer id (e.g. `cus_...`) that will own the ChargeIntent. */
+            val id: String
+        ) : Owner()
+        /** An account-scoped owner; Google Pay charges produce a Transfer. */
+        data class Account(
+            /** The account id (e.g. `acc_...`) that will own the Transfer. */
+            val id: String
+        ) : Owner()
     }
 
+    /** Outcome of a Google Pay flow initiated by [FrameGooglePayButton]. */
     sealed class Result {
         /**
          * Charge mode: payment authorized and the downstream resource was created.
          * `id` is a ChargeIntent id when the owner was [Owner.Customer], or a Transfer id
          * when the owner was [Owner.Account].
          */
-        data class Success(val id: String) : Result()
+        data class Success(
+            /** The id of the created ChargeIntent or Transfer, depending on [Owner] type. */
+            val id: String
+        ) : Result()
         /** AddToOwner mode: wallet card was attached to the customer/account as a PaymentMethod. */
-        data class PaymentMethodCreated(val paymentMethod: FrameObjects.PaymentMethod) : Result()
+        data class PaymentMethodCreated(
+            /** The PaymentMethod that was created and attached. */
+            val paymentMethod: FrameObjects.PaymentMethod
+        ) : Result()
+        /** The Google Pay flow encountered an error; [message] contains a human-readable description. */
         data class Failure(val message: String) : Result()
+        /** The customer dismissed the Google Pay sheet without completing payment. */
         data object Cancelled : Result()
     }
 
-    /// Drives whether the Google Pay sheet completes by creating a charge (`Charge`) or
-    /// only attaches the wallet card to the customer/account (`AddToOwner`).
+    /**
+     * Controls whether the Google Pay sheet completes by creating a charge or only attaches
+     * the wallet card to the customer/account without charging.
+     */
     sealed class Mode {
+        /**
+         * Completes payment immediately by creating a ChargeIntent (customer owner) or
+         * Transfer (account owner).
+         *
+         * @property amountCents The amount to charge in cents.
+         * @property currencyCode ISO 4217 currency code (default: "USD").
+         * @property owner The customer or account that will own the resulting resource.
+         */
         data class Charge(
             val amountCents: Int,
             val currencyCode: String = "USD",
             val owner: Owner
         ) : Mode()
+
+        /**
+         * Attaches the wallet card as a PaymentMethod without creating a charge.
+         *
+         * @property customerId Customer to attach the payment method to, or null.
+         * @property accountId Account to attach the payment method to, or null.
+         */
         data class AddToOwner(val customerId: String?, val accountId: String?) : Mode()
     }
 
@@ -200,9 +234,16 @@ class FrameGooglePayButton @JvmOverloads constructor(
         )
     }
 
-    /// Mode-aware configure. Use `Mode.Charge` for the existing checkout flow or
-    /// `Mode.AddToOwner` to attach a Google Pay wallet card to a customer/account without
-    /// creating a charge intent.
+    /**
+     * Configures the button with an explicit [Mode] and checks Google Pay readiness.
+     *
+     * Use [Mode.Charge] for the standard checkout flow or [Mode.AddToOwner] to attach a
+     * Google Pay wallet card to a customer/account without creating a charge.
+     *
+     * @param mode The payment mode controlling charge vs. attach-only behavior.
+     * @param onResult Callback invoked with the payment result.
+     * @param onReadinessChanged Optional callback invoked when Google Pay availability changes.
+     */
     fun configure(
         mode: Mode,
         onResult: (Result) -> Unit,

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/buttons/FramePaymentButton.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/buttons/FramePaymentButton.kt
@@ -29,8 +29,29 @@ import com.framepayments.framesdk_ui.theme.LocalFrameTheme
  * Note: this is a *styled* button. For a fully functional Google Pay flow with charge-intent
  * creation, use [FrameGooglePayButton] instead.
  */
-enum class PaymentButtonOption { GOOGLE }
+/**
+ * Wallet provider options for [FramePaymentButton].
+ *
+ * Only [GOOGLE] is supported on Android; the `APPLE` constant is omitted here to preserve
+ * cross-platform API symmetry without shipping a non-functional option.
+ */
+enum class PaymentButtonOption {
+    /** Renders the Google Pay brand mark. */
+    GOOGLE
+}
 
+/**
+ * Renders a styled wallet-provider button with the brand mark centered on a pill-shaped
+ * black or white background.
+ *
+ * For a fully functional Google Pay flow with charge-intent creation, use
+ * [FrameGooglePayButton] instead.
+ *
+ * @param paymentOption Wallet brand to display (default: [PaymentButtonOption.GOOGLE]).
+ * @param blackButton When true renders a black pill; when false renders a white pill.
+ * @param modifier Modifier applied to the outer button.
+ * @param onClick Called when the customer taps the button.
+ */
 @Composable
 fun FramePaymentButton(
     paymentOption: PaymentButtonOption = PaymentButtonOption.GOOGLE,

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/buttons/GooglePayButton.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/buttons/GooglePayButton.kt
@@ -5,6 +5,12 @@ import android.util.AttributeSet
 import com.framepayments.framesdk_ui.R
 import com.google.android.material.button.MaterialButton
 
+/**
+ * Minimal Google Pay icon button used internally by [FrameGooglePayButton].
+ *
+ * Renders the Google Pay vector asset on a black rounded rectangle with no label text.
+ * Merchants should use [FrameGooglePayButton] for a fully functional Google Pay integration.
+ */
 class GooglePayButton @JvmOverloads constructor(
     ctx: Context, attrs: AttributeSet? = null
 ) : MaterialButton(ctx, attrs, com.google.android.material.R.attr.materialButtonOutlinedStyle) {

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/snackbar/FrameSnackbarController.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/snackbar/FrameSnackbarController.kt
@@ -34,8 +34,14 @@ object FrameSnackbarController {
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
+    /** Hot flow of transport-error messages; collect via [observeWithSnackbar] or [SnackbarBridge]. */
     val events: SharedFlow<String> = _events.asSharedFlow()
 
+    /**
+     * Emits [message] to all active observers.
+     *
+     * @param message Human-readable error string to display in a snackbar.
+     */
     fun emit(message: String) {
         _events.tryEmit(message)
     }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameColors.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameColors.kt
@@ -8,6 +8,30 @@ import androidx.compose.ui.platform.LocalContext
 import com.framepayments.framesdk_ui.R
 import androidx.core.content.ContextCompat
 
+/**
+ * Complete color token set for the Frame SDK UI.
+ *
+ * Pass a customized instance to [FrameTheme] to override the default palette across all SDK
+ * components. All token names mirror the iOS FrameColors struct for cross-platform consistency.
+ *
+ * @property primaryButton Background color of primary action buttons.
+ * @property primaryButtonText Text/icon color on top of [primaryButton].
+ * @property secondaryButton Background color of secondary action buttons.
+ * @property secondaryButtonText Text/icon color on top of [secondaryButton].
+ * @property disabledButton Background color of disabled buttons.
+ * @property disabledButtonStroke Stroke color of disabled buttons.
+ * @property disabledButtonText Text color of disabled buttons.
+ * @property surface Background color of card surfaces and input containers.
+ * @property surfaceStroke Border color of card surfaces and input containers.
+ * @property textPrimary Primary body and heading text color.
+ * @property textSecondary Secondary/hint text color.
+ * @property error Color used for validation error messages and indicators.
+ * @property toastBackground Background color of error snackbars.
+ * @property toastText Text color of error snackbars.
+ * @property onboardingHeaderBackground Background color of the onboarding progress header strip.
+ * @property onboardingProgressFilledOnBrand Filled segment color of the onboarding progress bar.
+ * @property onboardingProgressEmptyOnBrand Empty segment color of the onboarding progress bar.
+ */
 @Immutable
 data class FrameColors(
     val primaryButton: Color,
@@ -28,7 +52,17 @@ data class FrameColors(
     val onboardingProgressFilledOnBrand: Color,
     val onboardingProgressEmptyOnBrand: Color,
 ) {
+    /** Factory methods for constructing default [FrameColors] instances from resources. */
     companion object {
+        /**
+         * Builds the default color set from `frame_*` color resources for the given [context].
+         *
+         * Resources defined in `values-night/colors.xml` are resolved automatically when the
+         * device is in dark mode.
+         *
+         * @param context Android context used to resolve color resources.
+         * @return A [FrameColors] instance populated from the SDK's default resource values.
+         */
         fun defaults(context: Context): FrameColors {
             fun c(id: Int) = Color(ContextCompat.getColor(context, id))
             return FrameColors(
@@ -52,6 +86,11 @@ data class FrameColors(
             )
         }
 
+        /**
+         * Composable variant of [defaults] that resolves resources from [LocalContext].
+         *
+         * @return A [FrameColors] instance populated from the SDK's default resource values.
+         */
         @Composable
         fun defaults(): FrameColors = defaults(LocalContext.current)
     }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameFonts.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameFonts.kt
@@ -8,6 +8,21 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 
+/**
+ * Typography token set for the Frame SDK UI.
+ *
+ * Each slot maps to a Material 3 typography role with weight overrides applied so the visual
+ * hierarchy matches iOS. Pass a customized instance to [FrameTheme] to override fonts globally.
+ *
+ * @property title Large display text style used for screen titles.
+ * @property heading Medium display text style used for section headings.
+ * @property headline Prominent label text used for card headings and emphasized content.
+ * @property body Default body copy text style.
+ * @property bodySmall Smaller body copy used for secondary descriptions.
+ * @property label Semibold label used for form field labels and list item titles.
+ * @property caption Small text used for captions and footnotes.
+ * @property button Semibold text used inside action buttons.
+ */
 @Immutable
 data class FrameFonts(
     val title: TextStyle,
@@ -19,6 +34,7 @@ data class FrameFonts(
     val caption: TextStyle,
     val button: TextStyle,
 ) {
+    /** Factory methods for constructing default [FrameFonts] instances. */
     companion object {
         /**
          * Defaults map to Material 3 typography slots, with weight overrides applied so the

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameRadii.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameRadii.kt
@@ -4,6 +4,15 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+/**
+ * Corner-radius token set for the Frame SDK UI.
+ *
+ * Pass a customized instance to [FrameTheme] to adjust the rounding of all SDK surfaces.
+ *
+ * @property small Radius applied to small UI elements such as chips and badges (default: 8 dp).
+ * @property medium Radius applied to cards, input fields, and buttons (default: 10 dp).
+ * @property large Radius applied to large containers and bottom sheets (default: 16 dp).
+ */
 @Immutable
 data class FrameRadii(
     val small: Dp = 8.dp,

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameTheme.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameTheme.kt
@@ -6,12 +6,24 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 
+/**
+ * Immutable design token bundle that drives all Frame SDK UI components.
+ *
+ * Construct a custom instance and pass it to the [FrameTheme] composable or to
+ * [com.framepayments.framesdk_ui.FrameCartView.setTheme] /
+ * [com.framepayments.framesdk_ui.FrameCheckoutView.setTheme] to apply merchant branding.
+ *
+ * @property colors Color token set controlling palette across all SDK surfaces.
+ * @property fonts Typography token set controlling text styles across all SDK surfaces.
+ * @property radii Corner-radius token set controlling shape across all SDK surfaces.
+ */
 @Immutable
 data class FrameTheme(
     val colors: FrameColors,
     val fonts: FrameFonts,
     val radii: FrameRadii,
 ) {
+    /** Factory methods for constructing default [FrameTheme] instances. */
     companion object {
         /**
          * Default theme — pulls colors via [colorResource] (so dark mode "just works" via
@@ -57,6 +69,13 @@ val LocalFrameTheme = staticCompositionLocalOf<FrameTheme> {
     )
 }
 
+/**
+ * Installs [theme] into the composition tree so all nested SDK components read it via
+ * [LocalFrameTheme].
+ *
+ * @param theme Theme to provide to child composables (default: [FrameTheme.default]).
+ * @param content Composable content that receives the theme.
+ */
 @Composable
 fun FrameTheme(
     theme: FrameTheme = FrameTheme.default(),

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameThemeAppearance.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/theme/FrameThemeAppearance.kt
@@ -11,6 +11,16 @@ import com.framepayments.framesdk_ui.FrameCartAppearance
  * Only fields that map cleanly from the cross-platform theme tokens are populated.
  * Use [overlay] to layer Views-only customizations (titles, sizes, typefaces) on top.
  */
+/**
+ * Converts this [FrameTheme] to a [FrameCartAppearance] and merges an optional [overlay].
+ *
+ * Only token fields that map cleanly from the cross-platform theme are populated. Use [overlay]
+ * to layer Views-only customizations (titles, text sizes, typefaces) on top; overlay values
+ * win on conflict.
+ *
+ * @param overlay Optional appearance whose non-null fields override the theme-derived base.
+ * @return A [FrameCartAppearance] suitable for passing to [com.framepayments.framesdk_ui.FrameCartView.configure].
+ */
 fun FrameTheme.toCartAppearance(overlay: FrameCartAppearance? = null): FrameCartAppearance {
     val base = FrameCartAppearance(
         backgroundColor = colors.surface.toArgb(),

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/validation/FieldKey.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/validation/FieldKey.kt
@@ -1,12 +1,26 @@
 package com.framepayments.framesdk_ui.validation
 
+/**
+ * Identifies each validated input field in the checkout form.
+ *
+ * Used as a key in the [com.framepayments.framesdk_ui.viewmodels.FrameCheckoutViewModel]
+ * error map so each field can independently show or clear its validation message.
+ */
 enum class FieldKey {
+    /** Customer full name field. */
     NAME,
+    /** Customer email address field. */
     EMAIL,
+    /** Billing address line 1 field. */
     ADDRESS_LINE_1,
+    /** Billing city field. */
     CITY,
+    /** Billing state/region field. */
     STATE,
+    /** Billing zip/postal code field. */
     ZIP,
+    /** Billing country field. */
     COUNTRY,
+    /** Encrypted card input field. */
     CARD
 }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/validation/ValidationError.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/validation/ValidationError.kt
@@ -3,13 +3,29 @@ package com.framepayments.framesdk_ui.validation
 import androidx.annotation.StringRes
 import com.framepayments.framesdk_ui.R
 
+/**
+ * Typed validation failure for a checkout form field.
+ *
+ * Each constant carries a string resource reference so the UI can display a localized message
+ * without coupling validation logic to Android context.
+ *
+ * @property messageRes String resource ID of the human-readable error message.
+ */
 enum class ValidationError(@StringRes val messageRes: Int) {
+    /** Customer name is missing or does not contain a first and last name. */
     NAME_REQUIRED(R.string.error_name_required),
+    /** Email address is empty or does not match a valid format. */
     EMAIL_INVALID(R.string.error_email_invalid),
+    /** Billing address line 1 is empty. */
     ADDRESS_REQUIRED(R.string.error_address_required),
+    /** Billing city is empty. */
     CITY_REQUIRED(R.string.error_city_required),
+    /** Billing state/region is empty. */
     STATE_REQUIRED(R.string.error_state_required),
+    /** Zip/postal code is not a valid 5-digit US zip. */
     ZIP_INVALID(R.string.error_zip_invalid),
+    /** Country has not been selected. */
     COUNTRY_REQUIRED(R.string.error_country_required),
+    /** Card data is absent or not potentially valid per Evervault's check. */
     CARD_INVALID(R.string.error_card_invalid)
 }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/validation/Validators.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/validation/Validators.kt
@@ -2,10 +2,21 @@ package com.framepayments.framesdk_ui.validation
 
 import com.evervault.sdk.input.model.card.PaymentCardData
 
+/**
+ * Stateless checkout form validators used by [com.framepayments.framesdk_ui.FrameCheckoutView].
+ *
+ * Each function returns null on success or a [ValidationError] constant on failure.
+ */
 object Validators {
 
     private val EMAIL_REGEX = Regex("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$")
 
+    /**
+     * Validates that [value] contains at least a first and last name separated by whitespace.
+     *
+     * @param value Raw name string entered by the customer.
+     * @return Null if valid, [ValidationError.NAME_REQUIRED] otherwise.
+     */
     fun validateName(value: String?): ValidationError? {
         val trimmed = value?.trim().orEmpty()
         if (trimmed.isEmpty()) return ValidationError.NAME_REQUIRED
@@ -13,29 +24,71 @@ object Validators {
         return if (parts.size >= 2) null else ValidationError.NAME_REQUIRED
     }
 
+    /**
+     * Validates that [value] is a non-empty, well-formed email address.
+     *
+     * @param value Raw email string entered by the customer.
+     * @return Null if valid, [ValidationError.EMAIL_INVALID] otherwise.
+     */
     fun validateEmail(value: String?): ValidationError? {
         val trimmed = value?.trim().orEmpty()
         if (trimmed.isEmpty()) return ValidationError.EMAIL_INVALID
         return if (EMAIL_REGEX.matches(trimmed)) null else ValidationError.EMAIL_INVALID
     }
 
+    /**
+     * Validates that [value] is non-blank.
+     *
+     * @param value Address line 1 entered by the customer.
+     * @return Null if valid, [ValidationError.ADDRESS_REQUIRED] otherwise.
+     */
     fun validateAddressLine1(value: String?): ValidationError? =
         if (value.isNullOrBlank()) ValidationError.ADDRESS_REQUIRED else null
 
+    /**
+     * Validates that [value] is non-blank.
+     *
+     * @param value City name entered by the customer.
+     * @return Null if valid, [ValidationError.CITY_REQUIRED] otherwise.
+     */
     fun validateCity(value: String?): ValidationError? =
         if (value.isNullOrBlank()) ValidationError.CITY_REQUIRED else null
 
+    /**
+     * Validates that [value] is non-blank.
+     *
+     * @param value State or region entered by the customer.
+     * @return Null if valid, [ValidationError.STATE_REQUIRED] otherwise.
+     */
     fun validateState(value: String?): ValidationError? =
         if (value.isNullOrBlank()) ValidationError.STATE_REQUIRED else null
 
+    /**
+     * Validates that [value] is exactly 5 ASCII digits (US zip code format).
+     *
+     * @param value Zip code entered by the customer.
+     * @return Null if valid, [ValidationError.ZIP_INVALID] otherwise.
+     */
     fun validateZip(value: String?): ValidationError? {
         val v = value.orEmpty()
         return if (v.length == 5 && v.all { it.isDigit() }) null else ValidationError.ZIP_INVALID
     }
 
+    /**
+     * Validates that [alpha2Code] is non-blank.
+     *
+     * @param alpha2Code ISO 3166-1 alpha-2 country code selected by the customer.
+     * @return Null if valid, [ValidationError.COUNTRY_REQUIRED] otherwise.
+     */
     fun validateCountry(alpha2Code: String?): ValidationError? =
         if (alpha2Code.isNullOrBlank()) ValidationError.COUNTRY_REQUIRED else null
 
+    /**
+     * Validates Evervault card data using its built-in potential-validity check.
+     *
+     * @param cardData Card data snapshot from [com.framepayments.framesdk_ui.EncryptedPaymentCardInput].
+     * @return Null if the card is potentially valid, [ValidationError.CARD_INVALID] otherwise.
+     */
     fun validateCard(cardData: PaymentCardData?): ValidationError? =
         if (cardData != null && cardData.isPotentiallyValid) null else ValidationError.CARD_INVALID
 }

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/viewmodels/AvailableCountries.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/viewmodels/AvailableCountries.kt
@@ -3,13 +3,22 @@ package com.framepayments.framesdk_ui.viewmodels
 import java.util.Locale
 
 
+/**
+ * Provides the full list of selectable countries for the checkout country picker.
+ */
 class AvailableCountries {
+    /** Static country list and default selection for the checkout country picker. */
     companion object {
+        /** Pre-selected country used when no prior selection exists (United States). */
         val defaultCountry: AvailableCountry = AvailableCountry(
             alpha2Code = "US",
             displayName = "United States"
         )
 
+        /**
+         * Lazily built list of all ISO 3166-1 countries sorted by display name in the
+         * device's default locale.
+         */
         val allCountries: List<AvailableCountry> by lazy {
             Locale.getISOCountries().map { code ->
                 val locale = Locale.Builder().setRegion(code).build()
@@ -19,4 +28,10 @@ class AvailableCountries {
     }
 }
 
+/**
+ * A country entry used in the checkout country picker.
+ *
+ * @property alpha2Code ISO 3166-1 alpha-2 code (e.g. "US", "GB").
+ * @property displayName Localized country name shown to the customer.
+ */
 data class AvailableCountry(val alpha2Code: String, val displayName: String)

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/viewmodels/FrameCartViewModel.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/viewmodels/FrameCartViewModel.kt
@@ -2,6 +2,15 @@ package com.framepayments.framesdk_ui.viewmodels
 
 import com.framepayments.framesdk_ui.FrameCartItem
 
+/**
+ * ViewModel for the cart summary surface.
+ *
+ * Computes totals from a list of [FrameCartItem]s plus a flat shipping amount.
+ *
+ * @property shippingAmount Shipping cost in cents added to the item subtotal.
+ * @property subtotal Sum of all item amounts in cents.
+ * @property finalTotal Total amount in cents (subtotal + shipping) passed to the payment flow.
+ */
 class FrameCartViewModel(
     items: List<FrameCartItem>,
     val shippingAmount: Int

--- a/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/viewmodels/FrameCheckoutViewModel.kt
+++ b/FrameSDK-UI/src/main/java/com/framepayments/framesdk_ui/viewmodels/FrameCheckoutViewModel.kt
@@ -19,46 +19,69 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+/**
+ * ViewModel for the checkout surface.
+ *
+ * Holds the observable state for payer details, saved payment methods, field validation errors,
+ * and the in-flight action indicator. Call [loadAccountDetails] once after construction to
+ * pre-fill name/email and load saved cards. Call [checkoutWithSelectedPaymentMethod] to submit.
+ */
 class FrameCheckoutViewModel : ViewModel() {
 
-    // Observable account payment options
     private val _accountPaymentOptions = MutableLiveData<List<FrameObjects.PaymentMethod>?>(null)
+    /** Saved payment methods belonging to the account; null until [loadAccountDetails] completes. */
     val accountPaymentOptions: LiveData<List<FrameObjects.PaymentMethod>?> = _accountPaymentOptions
 
-    /// True once `loadAccountDetails` has finished fetching saved payment methods. The view
-    /// defers rendering the new-card section until this flips, so returning users don't see
-    /// the Card/Billing block flash visible before the auto-selection of their first saved method.
     private val _didLoadAccountPaymentMethods = MutableLiveData(false)
+    /**
+     * True once [loadAccountDetails] has finished fetching saved payment methods. The view
+     * defers rendering the new-card section until this flips, so returning users don't see
+     * the Card/Billing block flash visible before auto-selection of their first saved method.
+     */
     val didLoadAccountPaymentMethods: LiveData<Boolean> = _didLoadAccountPaymentMethods
 
-    // Customer-facing fields (payer details entered at checkout)
+    /** Customer's full name entered in the checkout form. */
     val customerName = MutableLiveData("")
+    /** Customer's email address entered in the checkout form. */
     val customerEmail = MutableLiveData("")
+    /** Customer's primary street address entered in the checkout form. */
     val customerAddressLine1 = MutableLiveData("")
+    /** Customer's secondary address line (apartment, suite, etc.) entered in the checkout form. */
     val customerAddressLine2 = MutableLiveData("")
+    /** Customer's city entered in the checkout form. */
     val customerCity = MutableLiveData("")
+    /** Customer's state or province entered in the checkout form. */
     val customerState = MutableLiveData("")
+    /** Customer's selected country from the checkout country picker. */
     var customerCountry: AvailableCountry = AvailableCountries.defaultCountry
+    /** Customer's ZIP or postal code entered in the checkout form. */
     val customerZipCode = MutableLiveData("")
 
-    // Selected payment method (LiveData so the view can react to selection changes).
     private val _selectedAccountPaymentOption = MutableLiveData<FrameObjects.PaymentMethod?>(null)
+    /** The payment method selected from [accountPaymentOptions]; null when entering a new card. */
     val selectedAccountPaymentOption: LiveData<FrameObjects.PaymentMethod?> = _selectedAccountPaymentOption
 
+    /** Sets [selectedAccountPaymentOption] and recomputes [hasUsablePaymentInput]. */
     fun setSelectedAccountPaymentOption(method: FrameObjects.PaymentMethod?) {
         _selectedAccountPaymentOption.value = method
         recomputeUsablePaymentInput()
     }
 
+    /**
+     * Encrypted card data from the Evervault card input. Setting this value recomputes
+     * [hasUsablePaymentInput].
+     */
     var cardData: PaymentCardData = PaymentCardData()
         set(value) {
             field = value
             recomputeUsablePaymentInput()
         }
 
-    /// Clear field errors that only apply to the new-card flow. Called when the user
-    /// selects a saved payment method so stale validation messages don't linger
-    /// behind the collapsed Card/Billing sections.
+    /**
+     * Clears field errors that only apply to the new-card flow. Call when the customer selects
+     * a saved payment method so stale validation messages don't linger behind the collapsed
+     * Card/Billing sections.
+     */
     fun clearNewCardFieldErrors() {
         val current = _fieldErrors.value.orEmpty().toMutableMap()
         current.remove(FieldKey.CARD)
@@ -70,11 +93,11 @@ class FrameCheckoutViewModel : ViewModel() {
         _fieldErrors.value = current
     }
 
-    /**
-     * True when the user has either selected a saved payment method
-     * or entered card details that pass Evervault's potential-validity check.
-     */
     private val _hasUsablePaymentInput = MutableLiveData(false)
+    /**
+     * True when the customer has either selected a saved payment method or entered card details
+     * that pass Evervault's potential-validity check. Drives the pay button's enabled state.
+     */
     val hasUsablePaymentInput: LiveData<Boolean> = _hasUsablePaymentInput
 
     private fun recomputeUsablePaymentInput() {
@@ -84,18 +107,21 @@ class FrameCheckoutViewModel : ViewModel() {
         _hasUsablePaymentInput.postValue(_selectedAccountPaymentOption.value != null || newCardOk)
     }
 
-    // Address mode + per-field errors
+    /** Controls whether the billing address section is required, optional, or hidden. */
     var addressMode: AddressMode = AddressMode.REQUIRED
     private val _fieldErrors = MutableLiveData<Map<FieldKey, ValidationError>>(emptyMap())
+    /** Per-field validation errors surfaced to the UI; empty map when no errors are present. */
     val fieldErrors: LiveData<Map<FieldKey, ValidationError>> = _fieldErrors
 
     // Internal tracking
     private var currentAccountId: String? = null
     internal var amount: Int = 0
 
-    /// True while the checkout submit is in flight. Drives the pay button's disabled state and
-    /// the in-button progress indicator. Re-entrant submit calls bail out immediately.
     private val _isPerformingAction = MutableLiveData(false)
+    /**
+     * True while the checkout submit is in-flight. Drives the pay button's disabled state and
+     * the in-button progress indicator. Re-entrant submit calls bail out immediately.
+     */
     val isPerformingAction: LiveData<Boolean> = _isPerformingAction
 
     /**
@@ -143,12 +169,23 @@ class FrameCheckoutViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Sets or clears the validation error for [key]. Passing `null` for [error] removes the entry.
+     *
+     * @param key The form field whose error state should be updated.
+     * @param error The validation error to display, or null to clear the current error.
+     */
     fun setError(key: FieldKey, error: ValidationError?) {
         val current = _fieldErrors.value.orEmpty().toMutableMap()
         if (error == null) current.remove(key) else current[key] = error
         _fieldErrors.postValue(current)
     }
 
+    /**
+     * Removes the validation error for [key] if one is present; no-op otherwise.
+     *
+     * @param key The form field whose error should be cleared.
+     */
     fun clearError(key: FieldKey) {
         val current = _fieldErrors.value.orEmpty()
         if (!current.containsKey(key)) return
@@ -193,6 +230,16 @@ class FrameCheckoutViewModel : ViewModel() {
         return errors
     }
 
+    /**
+     * Validates inputs and submits the checkout.
+     *
+     * If a saved payment method is selected, the new-card fields are skipped during validation.
+     * Creates the payment method if needed, then creates a Transfer against [currentAccountId].
+     * Emits `null` on validation failure, a missing account id, or a networking error.
+     *
+     * @param saveMethod Whether to persist the new card as a saved payment method (currently unused).
+     * @return [LiveData] that emits the created [Transfer] on success, or null on failure.
+     */
     fun checkoutWithSelectedPaymentMethod(saveMethod: Boolean): LiveData<Transfer?> = liveData(Dispatchers.IO) {
         if (amount == 0) {
             emit(null)

--- a/FrameSDK/build.gradle.kts
+++ b/FrameSDK/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     alias(libs.plugins.android.library)
     kotlin("android") version "2.2.10"
     id("com.vanniktech.maven.publish")
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.dokka)
 }
 
 android {
@@ -92,6 +94,16 @@ mavenPublishing {
 
     publishToMavenCentral(automaticRelease = false)
     signAllPublications()
+}
+
+detekt {
+    config.setFrom(rootProject.file("config/detekt/detekt.yml"))
+    source.setFrom("src/main/java")
+    autoCorrect = false
+}
+
+tasks.named("dokkaHtml") {
+    outputs.upToDateWhen { false }
 }
 
 // CI: print per-test pass/fail names instead of the silent default. Helps surface

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/CommonNetworkObject.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/CommonNetworkObject.kt
@@ -2,7 +2,18 @@ package com.framepayments.framesdk
 
 import com.google.gson.annotations.SerializedName
 
+/** Common Frame API domain objects shared across multiple SDK modules. */
 object FrameObjects {
+    /**
+     * A postal billing or shipping address.
+     *
+     * @property city City name.
+     * @property country ISO 3166-1 alpha-2 country code.
+     * @property state State or province code.
+     * @property postalCode ZIP or postal code.
+     * @property addressLine1 Primary street address.
+     * @property addressLine2 Apartment, suite, or other secondary address information.
+     */
     data class BillingAddress(
         val city: String?,
         val country: String?,
@@ -12,21 +23,48 @@ object FrameObjects {
         @SerializedName("line_2") val addressLine2: String?
     )
 
+    /** Lifecycle status of a payment method on the Frame platform. */
     enum class PaymentMethodStatus {
+        /** The payment method is active and can be used for transactions. */
         @SerializedName("active") ACTIVE,
+
+        /** The payment method has been blocked and cannot be used. */
         @SerializedName("blocked") BLOCKED
     }
 
+    /** The funding instrument type of a payment method. */
     enum class PaymentMethodType {
+        /** A credit or debit card. */
         @SerializedName("card") CARD,
+
+        /** An ACH bank account. */
         @SerializedName("ach") ACH
     }
 
+    /** The type of a bank account used for ACH payments. */
     enum class PaymentAccountType {
+        /** A checking account. */
         @SerializedName("checking") CHECKING,
+
+        /** A savings account. */
         @SerializedName("savings") SAVINGS
     }
 
+    /**
+     * A payment method stored on the Frame platform.
+     *
+     * @property id Unique identifier for the payment method.
+     * @property customerId The customer this payment method belongs to, if customer-scoped.
+     * @property billing Billing address associated with this payment method.
+     * @property type Whether this is a [PaymentMethodType.CARD] or [PaymentMethodType.ACH] method.
+     * @property methodObject The Frame API object type string (e.g. `"payment_method"`).
+     * @property created Unix timestamp when the payment method was created.
+     * @property updated Unix timestamp when the payment method was last updated.
+     * @property livemode `true` if this is a live-mode resource; `false` for test-mode.
+     * @property card Card details when [type] is [PaymentMethodType.CARD].
+     * @property ach Bank account details when [type] is [PaymentMethodType.ACH].
+     * @property status Current [PaymentMethodStatus] of this payment method.
+     */
     data class PaymentMethod(
         val id: String?,
         @SerializedName("customer_id") val customerId: String? = null,
@@ -41,6 +79,19 @@ object FrameObjects {
         val status: PaymentMethodStatus?
     )
 
+    /**
+     * Card details for a payment method of type [PaymentMethodType.CARD].
+     *
+     * @property brand Card network name (e.g. `"visa"`, `"mastercard"`).
+     * @property expirationMonth Two-digit expiration month.
+     * @property expirationYear Four-digit expiration year.
+     * @property issuer The issuing bank name.
+     * @property currency ISO 4217 billing currency code.
+     * @property segment Card segment (e.g. `"consumer"`, `"commercial"`).
+     * @property type Card funding type (e.g. `"debit"`, `"credit"`).
+     * @property lastFourDigits The last four digits of the card number.
+     * @property wallet Digital wallet details, if this card is tokenized in a wallet.
+     */
     data class PaymentCard(
         val brand: String?,
         @SerializedName("exp_month") val expirationMonth: String?,
@@ -53,16 +104,35 @@ object FrameObjects {
         val wallet: Wallet? = null
     )
 
+    /** The digital wallet type that tokenized a card. */
     enum class WalletType {
+        /** Apple Pay. */
         @SerializedName("apple_pay") APPLE_PAY,
+
+        /** Google Pay. */
         @SerializedName("google_pay") GOOGLE_PAY
     }
 
+    /**
+     * Digital wallet details for a card tokenized through Apple Pay or Google Pay.
+     *
+     * @property type The wallet provider.
+     * @property dynamicLast4 The dynamic last-four digits assigned by the wallet (may differ from the physical card).
+     */
     data class Wallet(
         val type: WalletType?,
         @SerializedName("dynamic_last4") val dynamicLast4: String?
     )
 
+    /**
+     * Bank account details for a payment method of type [PaymentMethodType.ACH].
+     *
+     * @property accountType Whether this is a [PaymentAccountType.CHECKING] or [PaymentAccountType.SAVINGS] account.
+     * @property bankName Name of the financial institution.
+     * @property accountNumber Full bank account number. Present only in contexts where it is explicitly returned.
+     * @property routingNumber ABA routing number.
+     * @property lastFour Last four digits of the account number.
+     */
     data class BankAccount(
         @SerializedName("account_type") val accountType: PaymentAccountType?,
         @SerializedName("bank_name") val bankName: String?,
@@ -71,11 +141,33 @@ object FrameObjects {
         @SerializedName("last_four") val lastFour: String?
     )
 
+    /** Lifecycle status of a customer on the Frame platform. */
     enum class CustomerStatus {
+        /** The customer account is active. */
         @SerializedName("active") ACTIVE,
+
+        /** The customer account has been blocked. */
         @SerializedName("blocked") BLOCKED
     }
 
+    /**
+     * A customer record on the Frame platform.
+     *
+     * @property id Unique identifier for the customer.
+     * @property created Unix timestamp when the customer was created.
+     * @property updated Unix timestamp when the customer was last updated.
+     * @property livemode `true` if this is a live-mode resource; `false` for test-mode.
+     * @property name Customer's full name.
+     * @property status Current [CustomerStatus] of this customer.
+     * @property phone Customer's phone number in E.164 format.
+     * @property email Customer's email address.
+     * @property description Optional merchant-supplied description for this customer.
+     * @property dateOfBirth Date of birth in `YYYY-MM-DD` format.
+     * @property customerObject The Frame API object type string (`"customer"`).
+     * @property shippingAddress Customer's shipping address.
+     * @property billingAddress Customer's billing address.
+     * @property paymentMethods Payment methods attached to this customer.
+     */
     data class Customer(
         val id: String?,
         val created: Int?,
@@ -86,7 +178,7 @@ object FrameObjects {
         val phone: String?,
         val email: String?,
         val description: String?,
-        @SerializedName("date_of_birth") val dateOfBirth: String?, // YYYY-MM-DD
+        @SerializedName("date_of_birth") val dateOfBirth: String?,
         @SerializedName("object") val customerObject: String?,
         @SerializedName("shipping_address") val shippingAddress: BillingAddress?,
         @SerializedName("billing_address") val billingAddress: BillingAddress?,
@@ -94,30 +186,73 @@ object FrameObjects {
     )
 }
 
-data class EmptyRequest (
+/**
+ * An empty request body placeholder used for API calls that require a POST with no payload.
+ *
+ * @property description Unused field present to satisfy serialization requirements.
+ */
+data class EmptyRequest(
     val description: String?
 )
 
+/**
+ * A single URL query-string parameter.
+ *
+ * @property name The parameter name.
+ * @property value The parameter value, or null to omit the value.
+ */
 data class QueryItem(val name: String, val value: String?)
 
+/**
+ * Pagination metadata returned by Frame list endpoints.
+ *
+ * @property page The current page number.
+ * @property url The URL of the current page.
+ * @property hasMore Whether additional pages of results are available.
+ */
 data class FrameMetadata(
     val page: Int?,
     val url: String?,
     @SerializedName("has_more") val hasMore: Boolean?
 )
 
+/**
+ * The multipart form-data field name for a document image upload.
+ *
+ * @property value The string value used as the form-data part name in the multipart upload.
+ */
 enum class FileUploadFieldName(val value: String) {
+    /** The front side of an identity document. */
     FRONT("front"),
+
+    /** The back side of an identity document. */
     BACK("back"),
+
+    /** A selfie photo of the customer. */
     SELFIE("selfie")
 }
 
+/**
+ * A bitmap image prepared for upload to the Frame document verification endpoint.
+ *
+ * @property bitmap The image to upload.
+ * @property fieldName Which document side or selfie this image represents.
+ */
 data class FileUpload(
     val bitmap: android.graphics.Bitmap,
     val fieldName: FileUploadFieldName
 ) {
+    /** The filename used in the multipart upload, derived from [fieldName]. */
     val fileName: String get() = "${fieldName.value}.jpg"
+
+    /** MIME type for the uploaded image. */
     val mimeType: String = "image/jpeg"
+
+    /**
+     * Compresses the bitmap to a JPEG byte array at 30% quality for upload.
+     *
+     * @return JPEG-encoded bytes.
+     */
     fun toByteArray(): ByteArray {
         val stream = java.io.ByteArrayOutputStream()
         bitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 30, stream)

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/FrameNetworking.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/FrameNetworking.kt
@@ -23,15 +23,31 @@ import java.io.IOException
 import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
 
+/** Default [URLSessionProtocol] implementation backed by OkHttp. */
 class DefaultURLSession(private val client: OkHttpClient) : URLSessionProtocol {
     override suspend fun execute(request: Request): Response = withContext(Dispatchers.IO) {
         client.newCall(request).execute()
     }
 }
 
+/**
+ * Central SDK singleton. Initialize once with [initializeWithAPIKey] from your `Application.onCreate`
+ * before using any Frame UI component or API client.
+ *
+ * @sample
+ * ```kotlin
+ * FrameNetworking.initializeWithAPIKey(
+ *     context = this,
+ *     secretKey = "sk_test_...",
+ *     publishableKey = "pk_test_...",
+ * )
+ * ```
+ */
 object FrameNetworking {
+    /** Gson instance shared across all SDK API clients. */
     val gson: Gson = Gson()
 
+    /** Shared OkHttp client configured with Frame's standard timeouts. */
     val okHttpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
             .callTimeout(30, TimeUnit.SECONDS)
@@ -40,12 +56,26 @@ object FrameNetworking {
             .writeTimeout(20, TimeUnit.SECONDS)
             .build()
     }
+
+    /** HTTP session used for all suspend-based API calls. Replace in tests to inject a mock. */
     var asyncURLSession: URLSessionProtocol = DefaultURLSession(okHttpClient)
+
+    /** Base URL for all Frame API requests. Defaults to the production endpoint. */
     var mainApiUrl: String = NetworkingConstants.MAIN_API_URL
+
+    /** The current SDK version string, sourced from `BuildConfig`. */
     const val CURRENT_VERSION = BuildConfig.SDK_VERSION
+
+    /** The secret key set during [initializeWithAPIKey]. Used as the Bearer token for most API calls. */
     var apiSecretKey: String = ""
+
+    /** The publishable key set during [initializeWithAPIKey]. Used for client-safe API calls. */
     var apiPublishableKey: String = ""
+
+    /** When `true`, request URLs, request bodies, and response bodies are printed to logcat. */
     var debugMode: Boolean = false
+
+    /** `true` once Evervault has been successfully configured; `false` until then. */
     var isEvervaultConfigured: Boolean = false
 
     /**
@@ -60,6 +90,15 @@ object FrameNetworking {
 
     private lateinit var applicationContext: Context
 
+    /**
+     * Initializes the Frame SDK. Call once from `Application.onCreate` before using any SDK component.
+     *
+     * @param context The application context.
+     * @param secretKey Your Frame secret key (`sk_...`). Keep this key server-side where possible.
+     * @param publishableKey Your Frame publishable key (`pk_...`). Safe to embed in the app.
+     * @param googlePayMerchantId Optional Google Pay merchant identifier. Required to show the Google Pay button in checkout.
+     * @param debug When `true`, API requests and responses are logged to logcat.
+     */
     fun initializeWithAPIKey(
         context: Context,
         secretKey: String,
@@ -117,8 +156,14 @@ object FrameNetworking {
         }
     }
 
+    /** Returns the current Sonar session identifier, or `null` if Sonar has not been initialized. */
     fun currentSonarSessionId(): String? = sonarSessionManager?.getSessionId()
 
+    /**
+     * Returns the application context stored during [initializeWithAPIKey].
+     *
+     * @throws IllegalStateException if called before [initializeWithAPIKey].
+     */
     fun getContext(): Context {
         check(::applicationContext.isInitialized) { "FrameSDK must be initialized before use" }
         return applicationContext
@@ -152,6 +197,12 @@ object FrameNetworking {
         return applyFrameHeaders(SiftManager.getCachedIPAddress(), usePublishableKey)
     }
 
+    /**
+     * Deserializes [data] from JSON into type [T], or returns `null` on failure.
+     *
+     * @param data Raw JSON bytes from a network response.
+     * @return The deserialized object, or `null` if [data] is null or parsing fails.
+     */
     inline fun <reified T> parseResponse(data: ByteArray?): T? {
         if (data == null) return null
         return try {
@@ -164,6 +215,12 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Deserializes [data] from a JSON array into a list of [T], or returns `null` on failure.
+     *
+     * @param data Raw JSON bytes from a network response.
+     * @return The deserialized list, or `null` if [data] is null or parsing fails.
+     */
     inline fun <reified T> parseListResponse(data: ByteArray?): List<T>? {
         if (data == null) return null
         return try {
@@ -176,6 +233,13 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Executes a GET or DELETE request to [endpoint] and returns the raw response bytes.
+     *
+     * @param endpoint The endpoint to call.
+     * @param usePublishableKey When `true`, the publishable key is used instead of the secret key.
+     * @return A pair of (response bytes, error). On success the error is `null`; on failure the bytes may contain an error body.
+     */
     suspend fun performDataTask(
         endpoint: FrameNetworkingEndpoints,
         usePublishableKey: Boolean = false
@@ -222,6 +286,14 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Executes a POST or PATCH request to [endpoint], serializing [request] as the JSON body.
+     *
+     * @param endpoint The endpoint to call.
+     * @param request Optional request body. Serialized to JSON via Gson.
+     * @param usePublishableKey When `true`, the publishable key is used instead of the secret key.
+     * @return A pair of (response bytes, error).
+     */
     suspend fun performDataTaskWithRequest(
         endpoint: FrameNetworkingEndpoints,
         request: Any? = null,
@@ -283,6 +355,14 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Executes a multipart POST to [endpoint], uploading each [FileUpload] as a form-data part.
+     *
+     * @param endpoint The endpoint to call.
+     * @param filesToUpload One or more document images to include in the upload.
+     * @param usePublishableKey When `true`, the publishable key is used instead of the secret key.
+     * @return A pair of (response bytes, error).
+     */
     suspend fun performMultipartDataTask(
         endpoint: FrameNetworkingEndpoints,
         filesToUpload: List<FileUpload>,
@@ -331,6 +411,14 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Callback-based multipart POST for callers that cannot use coroutines.
+     *
+     * @param endpoint The endpoint to call.
+     * @param filesToUpload One or more document images to include in the upload.
+     * @param usePublishableKey When `true`, the publishable key is used instead of the secret key.
+     * @param completion Called on an OkHttp worker thread with the response bytes and any error.
+     */
     fun performMultipartDataTask(
         endpoint: FrameNetworkingEndpoints,
         filesToUpload: List<FileUpload>,
@@ -376,6 +464,13 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Callback-based GET/DELETE for callers that cannot use coroutines.
+     *
+     * @param endpoint The endpoint to call.
+     * @param usePublishableKey When `true`, the publishable key is used instead of the secret key.
+     * @param completion Called on an OkHttp worker thread with the response bytes and any error.
+     */
     fun performDataTask(
         endpoint: FrameNetworkingEndpoints,
         usePublishableKey: Boolean = false,
@@ -418,6 +513,14 @@ object FrameNetworking {
         }
     }
 
+    /**
+     * Callback-based POST/PATCH for callers that cannot use coroutines.
+     *
+     * @param endpoint The endpoint to call.
+     * @param request Optional request body. Serialized to JSON via Gson.
+     * @param usePublishableKey When `true`, the publishable key is used instead of the secret key.
+     * @param completion Called on an OkHttp worker thread with the response bytes and any error.
+     */
     fun <T> performDataTaskWithRequest(
         endpoint: FrameNetworkingEndpoints,
         request: T? = null,
@@ -506,6 +609,10 @@ object FrameNetworking {
         return true
     }
 
+    /**
+     * Loads Evervault credentials from secure storage or the Frame API (callback-based variant).
+     * Prefer [ensureEvervaultReadyForCardInputs] from a coroutine when possible.
+     */
     fun configureEvervault() {
         val config: ConfigurationResponses.GetEvervaultConfigurationResponse? =
             SecureConfigurationStorage.retrieve(getContext(), "evervault")

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/FrameResult.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/FrameResult.kt
@@ -11,9 +11,24 @@ package com.framepayments.framesdk
  * - [Failed] is emitted for terminal errors that can't be retried in-flow.
  */
 sealed class FrameResult {
+    /** Emitted when the user completes the flow. [id] is the resource produced by the flow. */
     data class Completed(val id: String) : FrameResult()
+
+    /** Emitted when the user dismisses the surface without completing. */
     data object Cancelled : FrameResult()
+
+    /**
+     * Emitted for terminal errors that cannot be retried in-flow.
+     *
+     * @property error The underlying exception that caused the failure.
+     */
     data class Failed(val error: Throwable) : FrameResult()
 }
 
+/**
+ * Thrown when [FrameNetworking.initializeWithAPIKey] has not been called before a Frame
+ * SDK component is used, or when required configuration values are missing or invalid.
+ *
+ * @param message Description of the configuration problem.
+ */
 class FrameConfigurationError(message: String) : RuntimeException(message)

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/NetworkingConstants.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/NetworkingConstants.kt
@@ -1,7 +1,10 @@
 package com.framepayments.framesdk
 
+/** Base URL constants used by [FrameNetworking] when constructing API requests. */
 class NetworkingConstants {
+    /** Holds global URL constants for the Frame SDK. */
     companion object {
+        /** The default Frame API base URL. Override via [FrameNetworking.mainApiUrl] for testing or staging. */
         var MAIN_API_URL: String = "https://api.framepayments.com"
     }
 }

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/NetworkingProtocols.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/NetworkingProtocols.kt
@@ -3,24 +3,55 @@ import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONObject
 
+/** HTTP execution abstraction used by all Frame SDK API clients. */
 interface URLSessionProtocol {
+    /**
+     * Executes [request] and returns the raw HTTP response.
+     *
+     * @param request The OkHttp request to execute.
+     * @return The HTTP response. Callers are responsible for closing the response body.
+     */
     suspend fun execute(request: Request): Response
 }
 
+/** Describes a single Frame API endpoint: its URL, HTTP method, and optional query parameters. */
 interface FrameNetworkingEndpoints {
+    /** The fully qualified URL string for this endpoint. */
     val endpointURL: String
+
+    /** HTTP method, e.g. `"GET"`, `"POST"`, `"DELETE"`. */
     val httpMethod: String
+
+    /** Optional query-string parameters appended to [endpointURL]. */
     val queryItems: List<QueryItem>?
 }
 
+/**
+ * Errors that the Frame SDK network layer can surface to callers.
+ *
+ * Use [isTransport] to distinguish retryable connectivity failures from server-validation
+ * errors that require the user to correct their input.
+ */
 sealed class NetworkingError : Exception() {
+    /** The constructed URL was malformed and the request could not be sent. */
     data object InvalidURL : NetworkingError() {
         private fun readResolve(): Any = InvalidURL
     }
+
+    /** The server responded successfully, but the response body could not be decoded. */
     data object DecodingFailed : NetworkingError() {
         private fun readResolve(): Any = DecodingFailed
     }
+
+    /**
+     * The server returned a non-2xx status code.
+     *
+     * @property statusCode The HTTP status code returned by the server.
+     * @property errorDescription The raw response body, which may contain a Frame error envelope.
+     */
     data class ServerError(val statusCode: Int, val errorDescription: String) : NetworkingError()
+
+    /** An unexpected error occurred that does not fit a more specific category. */
     data object UnknownError : NetworkingError() {
         private fun readResolve(): Any = UnknownError
     }

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountEndpoints.kt
@@ -3,9 +3,13 @@ package com.framepayments.framesdk.accounts
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/** Sealed class defining all account API endpoints and their routing metadata. */
 sealed class AccountEndpoints : FrameNetworkingEndpoints {
+    /** Endpoint for creating a new account. */
     object CreateAccount : AccountEndpoints()
+    /** Endpoint for updating an existing account. */
     data class UpdateAccount(val accountId: String) : AccountEndpoints()
+    /** Endpoint for listing accounts with optional filters. */
     data class GetAccounts(
         val status: AccountObjects.AccountStatus? = null,
         val type: AccountObjects.AccountType? = null,
@@ -14,8 +18,11 @@ sealed class AccountEndpoints : FrameNetworkingEndpoints {
         val page: Int? = null,
         val perPage: Int? = null
     ) : AccountEndpoints()
+    /** Endpoint for retrieving a single account by ID. */
     data class GetAccountWith(val accountId: String) : AccountEndpoints()
+    /** Endpoint for deleting an account by ID. */
     data class DeleteAccountWith(val accountId: String) : AccountEndpoints()
+    /** Endpoint for searching accounts by criteria. */
     data class SearchAccounts(
         val email: String? = null,
         val externalId: String? = null,
@@ -24,10 +31,15 @@ sealed class AccountEndpoints : FrameNetworkingEndpoints {
         val createdBefore: String? = null,
         val createdAfter: String? = null
     ) : AccountEndpoints()
+    /** Endpoint for restricting an account from transacting. */
     data class RestrictAccount(val accountId: String) : AccountEndpoints()
+    /** Endpoint for removing a restriction from an account. */
     data class UnrestrictAccount(val accountId: String) : AccountEndpoints()
+    /** Endpoint for obtaining a Plaid Link token for an account. */
     data class GetPlaidLinkToken(val accountId: String, val androidPackageName: String) : AccountEndpoints()
+    /** Endpoint for initiating a phone verification for an account. */
     data class CreatePhoneVerification(val accountId: String) : AccountEndpoints()
+    /** Endpoint for confirming a phone verification with a one-time code. */
     data class ConfirmPhoneVerification(val accountId: String, val verificationId: String) : AccountEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountObjects.kt
@@ -4,35 +4,80 @@ import com.framepayments.framesdk.FrameObjects
 import com.framepayments.framesdk.capabilities.CapabilityObjects
 import com.google.gson.annotations.SerializedName
 
+/** Namespace for account domain model types. */
 object AccountObjects {
+
+    /** Classifies whether an account belongs to an individual or a business. */
     enum class AccountType {
+        /** A personal account held by an individual. */
         @SerializedName("individual") INDIVIDUAL,
+
+        /** A business account held by a company or organization. */
         @SerializedName("business") BUSINESS
     }
 
+    /** Lifecycle status of an account. */
     enum class AccountStatus {
+        /** Account has been created but not yet approved. */
         @SerializedName("pending") PENDING,
+        /** Account is in good standing and can transact. */
         @SerializedName("active") ACTIVE,
+        /** Account has been temporarily restricted from transacting. */
         @SerializedName("restricted") RESTRICTED,
+        /** Account has been permanently disabled. */
         @SerializedName("disabled") DISABLED
     }
 
+    /**
+     * Terms-of-service acceptance record for an account.
+     *
+     * @property token The terms-of-service token that was accepted.
+     * @property acceptedAt ISO-8601 timestamp of acceptance.
+     * @property ipAddress IP address from which the terms were accepted.
+     */
     data class AccountTermsOfService(
         val token: String? = null,
         @SerializedName("accepted_at") val acceptedAt: String? = null,
         @SerializedName("ip_address") val ipAddress: String? = null
     )
 
+    /**
+     * Profile information for an account, containing either business or individual data.
+     *
+     * @property business Business profile details, present when the account type is [AccountType.BUSINESS].
+     * @property individual Individual profile details, present when the account type is [AccountType.INDIVIDUAL].
+     */
     data class AccountProfile(
         val business: BusinessAccount? = null,
         val individual: IndividualAccount? = null
     )
 
+    /**
+     * A phone number associated with an account.
+     *
+     * @property number The phone number digits.
+     * @property countryCode The ISO country calling code (e.g., "1" for the US).
+     */
     data class AccountPhoneNumber(
         val number: String?,
         @SerializedName("country_code") val countryCode: String?
     )
 
+    /**
+     * Business profile data for a business account.
+     *
+     * @property legalBusinessName The registered legal name of the business.
+     * @property doingBusinessAs Optional trade name or DBA name.
+     * @property businessType The type or structure of the business (e.g., LLC, sole proprietorship).
+     * @property email Business contact email address.
+     * @property website Business website URL.
+     * @property description Brief description of the business.
+     * @property einLastFour Last four digits of the Employer Identification Number.
+     * @property mcc Merchant Category Code.
+     * @property naics North American Industry Classification System code.
+     * @property address Business physical address.
+     * @property phone Business phone number.
+     */
     data class BusinessAccount(
         @SerializedName("legal_business_name") val legalBusinessName: String?,
         @SerializedName("doing_business_as") val doingBusinessAs: String? = null,
@@ -47,6 +92,16 @@ object AccountObjects {
         val phone: AccountPhoneNumber? = null
     )
 
+    /**
+     * A billing or mailing address associated with an account.
+     *
+     * @property city City name.
+     * @property country ISO 3166-1 alpha-2 country code.
+     * @property state State or province.
+     * @property postalCode ZIP or postal code.
+     * @property addressLine1 Primary street address.
+     * @property addressLine2 Secondary address line (apartment, suite, etc.).
+     */
     data class AccountBillingAddress(
         val city: String? = null,
         val country: String? = null,
@@ -56,12 +111,33 @@ object AccountObjects {
         @SerializedName("line_2") val addressLine2: String? = null
     )
 
+    /**
+     * The name components of an individual account holder.
+     *
+     * @property firstName Legal first name.
+     * @property middleName Middle name or initial.
+     * @property lastName Legal last name.
+     * @property suffix Name suffix (e.g., Jr., III).
+     */
     data class IndividualAccountName(
         @SerializedName("first_name") val firstName: String? = null,
         @SerializedName("middle_name") val middleName: String? = null,
         @SerializedName("last_name") val lastName: String? = null,
         val suffix: String? = null
     )
+
+    /**
+     * Individual profile data for a personal account.
+     *
+     * @property name The account holder's name components.
+     * @property email Contact email address.
+     * @property ssnLastFour Last four digits of the Social Security Number.
+     * @property phoneNumber Contact phone number.
+     * @property phoneCountryCode ISO country calling code for the phone number.
+     * @property address Residential address.
+     * @property birthdate Date of birth in YYYY-MM-DD format.
+     * @property ssn Full Social Security Number; omitted from most responses.
+     */
     data class IndividualAccount(
         val name: IndividualAccountName? = null,
         val email: String? = null,
@@ -73,6 +149,15 @@ object AccountObjects {
         val ssn: String? = null
     )
 
+    /**
+     * A single onboarding or compliance step required for an account.
+     *
+     * @property key Unique identifier for this step.
+     * @property status Completion status of the step.
+     * @property label Human-readable label for the step.
+     * @property fields Fields associated with this step.
+     * @property currentlyDue Fields that are currently required to advance past this step.
+     */
     data class AccountStep(
         val key: String?,
         val status: String?,
@@ -81,6 +166,23 @@ object AccountObjects {
         @SerializedName("currently_due") val currentlyDue: List<String>?
     )
 
+    /**
+     * Represents a Frame account belonging to a merchant or their sub-merchant.
+     *
+     * @property id Unique account identifier.
+     * @property accountObject The API object type string (always `"account"`).
+     * @property type Whether the account is [AccountType.INDIVIDUAL] or [AccountType.BUSINESS].
+     * @property status The current lifecycle status of the account.
+     * @property externalId Merchant-assigned external identifier.
+     * @property metadata Arbitrary key-value pairs set by the merchant.
+     * @property termsOfService Terms-of-service acceptance record.
+     * @property profile Business or individual profile data.
+     * @property capabilities List of payment capabilities enabled for this account.
+     * @property steps Outstanding onboarding or compliance steps.
+     * @property created Unix timestamp of account creation.
+     * @property updated Unix timestamp of the last account update.
+     * @property livemode `true` when the account exists in the live environment.
+     */
     data class Account(
         val id: String?,
         @SerializedName("object") val accountObject: String?,
@@ -97,6 +199,17 @@ object AccountObjects {
         val livemode: Boolean?
     )
 
+    /**
+     * Represents a phone number verification attempt for an account.
+     *
+     * @property id Unique verification identifier.
+     * @property verificationObject The API object type string (always `"phone_verification"`).
+     * @property accountId ID of the account this verification belongs to.
+     * @property status Current status of the verification attempt.
+     * @property created Unix timestamp of creation.
+     * @property updated Unix timestamp of the last update.
+     * @property livemode `true` when the verification exists in the live environment.
+     */
     data class PhoneVerification(
         val id: String?,
         @SerializedName("object") val verificationObject: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountRequests.kt
@@ -3,8 +3,21 @@ package com.framepayments.framesdk.accounts
 import com.framepayments.framesdk.FrameObjects
 import com.google.gson.annotations.SerializedName
 
+/** Namespace for account request body types. */
 object AccountRequests {
 
+    /**
+     * Profile data for creating an individual account holder.
+     *
+     * @property name Name components of the account holder.
+     * @property email Contact email address. Either email or phone is required.
+     * @property phone Contact phone number. Either email or phone is required.
+     * @property address Residential address.
+     * @property birthdate Date of birth in YYYY-MM-DD format.
+     * @property ssn Full Social Security Number.
+     * @property ssnLast4 Last four digits of the Social Security Number.
+     * @property profileURL URL pointing to a profile image.
+     */
     data class CreateIndividualAccount(
         val name: AccountObjects.IndividualAccountName? = null,
         val email: String? = null, // Either email or phone number is required to create an account
@@ -16,11 +29,27 @@ object AccountRequests {
         @SerializedName("profile_url") val profileURL: String? = null
     )
 
+    /**
+     * Profile container used when creating an account; holds business or individual data.
+     *
+     * @property business Business profile details.
+     * @property individual Individual profile details.
+     */
     data class CreateAccountProfile(
         val business: AccountObjects.BusinessAccount? = null,
         val individual: CreateIndividualAccount? = null
     )
 
+    /**
+     * Request body for creating a new account.
+     *
+     * @property type Whether this is an individual or business account.
+     * @property externalId Merchant-assigned identifier for this account.
+     * @property termsOfService Terms-of-service acceptance record to attach at creation.
+     * @property metadata Arbitrary key-value pairs to store with the account.
+     * @property profile Business or individual profile data.
+     * @property capabilities List of capability keys to request for this account.
+     */
     data class CreateAccountRequest(
         val type: AccountObjects.AccountType,
         @SerializedName("external_id") val externalId: String? = null,
@@ -30,6 +59,14 @@ object AccountRequests {
         val capabilities: List<String> = emptyList()
     )
 
+    /**
+     * Name update fields for an individual account holder.
+     *
+     * @property firstName Updated legal first name.
+     * @property middleName Updated middle name or initial.
+     * @property lastName Updated legal last name.
+     * @property suffix Updated name suffix.
+     */
     data class UpdateAccountInfo(
         @SerializedName("first_name") val firstName: String? = null,
         @SerializedName("middle_name") val middleName: String? = null,
@@ -37,6 +74,19 @@ object AccountRequests {
         val suffix: String? = null
     )
 
+    /**
+     * Updated profile data for an individual account holder.
+     *
+     * @property name Updated name components.
+     * @property email Updated contact email address.
+     * @property phoneNumber Updated contact phone number.
+     * @property phoneCountryCode ISO country calling code for the updated phone number.
+     * @property address Updated residential address.
+     * @property birthdate Updated date of birth in YYYY-MM-DD format.
+     * @property ssn Updated full Social Security Number.
+     * @property ssnLast4 Updated last four digits of the Social Security Number.
+     * @property profileURL Updated profile image URL.
+     */
     data class UpdateIndividualAccount(
         val name: UpdateAccountInfo? = null,
         val email: String? = null,
@@ -49,6 +99,21 @@ object AccountRequests {
         @SerializedName("profile_url") val profileURL: String? = null
     )
 
+    /**
+     * Updated profile data for a business account.
+     *
+     * @property legalBusinessName Updated registered legal business name.
+     * @property doingBusinessAs Updated trade or DBA name.
+     * @property businessType Updated business structure type.
+     * @property email Updated business contact email.
+     * @property website Updated business website URL.
+     * @property description Updated business description.
+     * @property einLastFour Updated last four digits of the EIN.
+     * @property mcc Updated Merchant Category Code.
+     * @property naics Updated NAICS industry code.
+     * @property address Updated business address.
+     * @property phone Updated business phone number.
+     */
     data class UpdateBusinessAccount(
         @SerializedName("legal_business_name") val legalBusinessName: String? = null,
         @SerializedName("doing_business_as") val doingBusinessAs: String? = null,
@@ -63,11 +128,26 @@ object AccountRequests {
         val phone: AccountObjects.AccountPhoneNumber? = null
     )
 
+    /**
+     * Profile container used when updating an account.
+     *
+     * @property business Updated business profile details.
+     * @property individual Updated individual profile details.
+     */
     data class UpdateAccountProfile(
         val business: UpdateBusinessAccount? = null,
         val individual: UpdateIndividualAccount? = null
     )
 
+    /**
+     * Request body for updating an existing account.
+     *
+     * @property type Updated account type.
+     * @property externalId Updated merchant-assigned external identifier.
+     * @property termsOfService Updated terms-of-service acceptance record.
+     * @property metadata Updated arbitrary key-value pairs.
+     * @property profile Updated business or individual profile data.
+     */
     data class UpdateAccountRequest(
         val type: AccountObjects.AccountType? = null,
         @SerializedName("external_id") val externalId: String? = null,
@@ -76,6 +156,11 @@ object AccountRequests {
         val profile: UpdateAccountProfile? = null
     )
 
+    /**
+     * Request body for confirming a phone verification.
+     *
+     * @property code The one-time verification code sent to the account holder's phone.
+     */
     data class ConfirmPhoneVerificationRequest(
         val code: String
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountResponses.kt
@@ -3,17 +3,36 @@ package com.framepayments.framesdk.accounts
 import com.framepayments.framesdk.FrameMetadata
 import com.google.gson.annotations.SerializedName
 
+/** Namespace for account API response types. */
 object AccountResponses {
+
+    /**
+     * Paginated list of accounts returned by [AccountsAPI.getAccounts].
+     *
+     * @property meta Pagination metadata.
+     * @property data The list of accounts on the current page.
+     */
     data class ListAccountsResponse(
         val meta: FrameMetadata? = null,
         val data: List<AccountObjects.Account>? = null
     )
 
+    /**
+     * Paginated list of accounts returned by [AccountsAPI.searchAccounts].
+     *
+     * @property meta Pagination metadata.
+     * @property data The list of matching accounts.
+     */
     data class SearchAccountsResponse(
         val meta: FrameMetadata? = null,
         val data: List<AccountObjects.Account>? = null
     )
 
+    /**
+     * Response containing a Plaid Link token for initiating a bank-account connection.
+     *
+     * @property linkToken The short-lived token passed to the Plaid Link SDK.
+     */
     data class PlaidLinkTokenResponse(
         @SerializedName("link_token") val linkToken: String?
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/accounts/AccountsAPI.kt
@@ -5,8 +5,16 @@ import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 import com.framepayments.framesdk.managers.SiftManager
 
+/** Provides coroutine and callback-based operations for managing accounts. */
 object AccountsAPI {
     // MARK: Methods using coroutines
+
+    /**
+     * Creates a new account and emits a Sift login event on success.
+     *
+     * @param request The account creation payload.
+     * @return A pair of the created [AccountObjects.Account] and any [NetworkingError].
+     */
     suspend fun createAccount(request: AccountRequests.CreateAccountRequest): Pair<AccountObjects.Account?, NetworkingError?> {
         val endpoint = AccountEndpoints.CreateAccount
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -18,6 +26,13 @@ object AccountsAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Updates an existing account.
+     *
+     * @param accountId The ID of the account to update.
+     * @param request The fields to update.
+     * @return A pair of the updated [AccountObjects.Account] and any [NetworkingError].
+     */
     suspend fun updateAccount(accountId: String, request: AccountRequests.UpdateAccountRequest): Pair<AccountObjects.Account?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.UpdateAccount(accountId)
@@ -25,6 +40,17 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountObjects.Account>(it) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of accounts, optionally filtered.
+     *
+     * @param status Filter by account status.
+     * @param type Filter by account type.
+     * @param externalId Filter by the merchant-assigned external ID.
+     * @param includeDisabled When `true`, includes disabled accounts in the results.
+     * @param page Page number to retrieve.
+     * @param perPage Number of results per page.
+     * @return A pair of the [AccountResponses.ListAccountsResponse] and any [NetworkingError].
+     */
     suspend fun getAccounts(
         status: AccountObjects.AccountStatus? = null,
         type: AccountObjects.AccountType? = null,
@@ -38,6 +64,13 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountResponses.ListAccountsResponse>(it) }, error)
     }
 
+    /**
+     * Retrieves a single account by ID and emits a Sift login event on success.
+     *
+     * @param accountId The ID of the account to retrieve.
+     * @param forTesting When `true`, suppresses the Sift login event.
+     * @return A pair of the [AccountObjects.Account] and any [NetworkingError].
+     */
     suspend fun getAccountWith(accountId: String, forTesting: Boolean = false): Pair<AccountObjects.Account?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.GetAccountWith(accountId)
@@ -52,6 +85,12 @@ object AccountsAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Deletes an account by ID.
+     *
+     * @param accountId The ID of the account to delete.
+     * @return A pair of the deleted [AccountObjects.Account] and any [NetworkingError].
+     */
     suspend fun deleteAccountWith(accountId: String): Pair<AccountObjects.Account?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.DeleteAccountWith(accountId)
@@ -59,6 +98,17 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountObjects.Account>(it) }, error)
     }
 
+    /**
+     * Searches for accounts matching the given criteria.
+     *
+     * @param email Filter by email address.
+     * @param externalId Filter by merchant-assigned external ID.
+     * @param type Filter by account type.
+     * @param status Filter by account status.
+     * @param createdBefore ISO-8601 timestamp; return accounts created before this time.
+     * @param createdAfter ISO-8601 timestamp; return accounts created after this time.
+     * @return A pair of the [AccountResponses.SearchAccountsResponse] and any [NetworkingError].
+     */
     suspend fun searchAccounts(
         email: String? = null,
         externalId: String? = null,
@@ -75,6 +125,12 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountResponses.SearchAccountsResponse>(it) }, error)
     }
 
+    /**
+     * Restricts an account, preventing it from processing payments.
+     *
+     * @param accountId The ID of the account to restrict.
+     * @return A pair of the updated [AccountObjects.Account] and any [NetworkingError].
+     */
     suspend fun restrictAccount(accountId: String): Pair<AccountObjects.Account?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.RestrictAccount(accountId)
@@ -82,6 +138,12 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountObjects.Account>(it) }, error)
     }
 
+    /**
+     * Removes a restriction from an account.
+     *
+     * @param accountId The ID of the account to unrestrict.
+     * @return A pair of the updated [AccountObjects.Account] and any [NetworkingError].
+     */
     suspend fun unrestrictAccount(accountId: String): Pair<AccountObjects.Account?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.UnrestrictAccount(accountId)
@@ -89,6 +151,12 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountObjects.Account>(it) }, error)
     }
 
+    /**
+     * Initiates a phone verification for an account.
+     *
+     * @param accountId The ID of the account whose phone number to verify.
+     * @return A pair of the [AccountObjects.PhoneVerification] and any [NetworkingError].
+     */
     suspend fun createPhoneVerification(accountId: String): Pair<AccountObjects.PhoneVerification?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.CreatePhoneVerification(accountId)
@@ -96,6 +164,14 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountObjects.PhoneVerification>(it) }, error)
     }
 
+    /**
+     * Confirms a phone verification using the code sent to the account holder.
+     *
+     * @param accountId The ID of the account.
+     * @param verificationId The ID of the pending phone verification.
+     * @param request The confirmation payload containing the one-time code.
+     * @return A pair of the confirmed [AccountObjects.PhoneVerification] and any [NetworkingError].
+     */
     suspend fun confirmPhoneVerification(accountId: String, verificationId: String, request: AccountRequests.ConfirmPhoneVerificationRequest): Pair<AccountObjects.PhoneVerification?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.ConfirmPhoneVerification(accountId, verificationId)
@@ -103,6 +179,12 @@ object AccountsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<AccountObjects.PhoneVerification>(it) }, error)
     }
 
+    /**
+     * Retrieves a Plaid Link token for the given account to initiate a bank-account connection flow.
+     *
+     * @param accountId The ID of the account for which to generate the token.
+     * @return A pair of the [AccountResponses.PlaidLinkTokenResponse] and any [NetworkingError].
+     */
     suspend fun getPlaidLinkToken(accountId: String): Pair<AccountResponses.PlaidLinkTokenResponse?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = AccountEndpoints.GetPlaidLinkToken(accountId, androidPackageName = "com.framepayments.frame")
@@ -111,6 +193,13 @@ object AccountsAPI {
     }
 
     // MARK: Methods using callbacks
+
+    /**
+     * Creates a new account and emits a Sift login event on success.
+     *
+     * @param request The account creation payload.
+     * @param completionHandler Called with the created [AccountObjects.Account] or a [NetworkingError].
+     */
     fun createAccount(request: AccountRequests.CreateAccountRequest, completionHandler: (AccountObjects.Account?, NetworkingError?) -> Unit) {
         val endpoint = AccountEndpoints.CreateAccount
         FrameNetworking.performDataTaskWithRequest(endpoint, request) { data, error ->
@@ -123,6 +212,13 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Updates an existing account.
+     *
+     * @param accountId The ID of the account to update.
+     * @param request The fields to update.
+     * @param completionHandler Called with the updated [AccountObjects.Account] or a [NetworkingError].
+     */
     fun updateAccount(accountId: String, request: AccountRequests.UpdateAccountRequest, completionHandler: (AccountObjects.Account?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.UpdateAccount(accountId)
@@ -131,6 +227,17 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of accounts, optionally filtered.
+     *
+     * @param status Filter by account status.
+     * @param type Filter by account type.
+     * @param externalId Filter by the merchant-assigned external ID.
+     * @param includeDisabled When `true`, includes disabled accounts in the results.
+     * @param page Page number to retrieve.
+     * @param perPage Number of results per page.
+     * @param completionHandler Called with the [AccountResponses.ListAccountsResponse] or a [NetworkingError].
+     */
     fun getAccounts(
         status: AccountObjects.AccountStatus? = null,
         type: AccountObjects.AccountType? = null,
@@ -146,6 +253,12 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Retrieves a single account by ID and emits a Sift login event on success.
+     *
+     * @param accountId The ID of the account to retrieve.
+     * @param completionHandler Called with the [AccountObjects.Account] or a [NetworkingError].
+     */
     fun getAccountWith(accountId: String, completionHandler: (AccountObjects.Account?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.GetAccountWith(accountId)
@@ -159,6 +272,12 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Deletes an account by ID.
+     *
+     * @param accountId The ID of the account to delete.
+     * @param completionHandler Called with the deleted [AccountObjects.Account] or a [NetworkingError].
+     */
     fun deleteAccountWith(accountId: String, completionHandler: (AccountObjects.Account?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.DeleteAccountWith(accountId)
@@ -167,6 +286,17 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Searches for accounts matching the given criteria.
+     *
+     * @param email Filter by email address.
+     * @param externalId Filter by merchant-assigned external ID.
+     * @param type Filter by account type.
+     * @param status Filter by account status.
+     * @param createdBefore ISO-8601 timestamp; return accounts created before this time.
+     * @param createdAfter ISO-8601 timestamp; return accounts created after this time.
+     * @param completionHandler Called with the [AccountResponses.SearchAccountsResponse] or a [NetworkingError].
+     */
     fun searchAccounts(
         email: String? = null,
         externalId: String? = null,
@@ -185,6 +315,12 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Restricts an account, preventing it from processing payments.
+     *
+     * @param accountId The ID of the account to restrict.
+     * @param completionHandler Called with the updated [AccountObjects.Account] or a [NetworkingError].
+     */
     fun restrictAccount(accountId: String, completionHandler: (AccountObjects.Account?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.RestrictAccount(accountId)
@@ -193,6 +329,12 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Removes a restriction from an account.
+     *
+     * @param accountId The ID of the account to unrestrict.
+     * @param completionHandler Called with the updated [AccountObjects.Account] or a [NetworkingError].
+     */
     fun unrestrictAccount(accountId: String, completionHandler: (AccountObjects.Account?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.UnrestrictAccount(accountId)
@@ -201,6 +343,12 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Initiates a phone verification for an account.
+     *
+     * @param accountId The ID of the account whose phone number to verify.
+     * @param completionHandler Called with the [AccountObjects.PhoneVerification] or a [NetworkingError].
+     */
     fun createPhoneVerification(accountId: String, completionHandler: (AccountObjects.PhoneVerification?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.CreatePhoneVerification(accountId)
@@ -209,6 +357,14 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Confirms a phone verification using the code sent to the account holder.
+     *
+     * @param accountId The ID of the account.
+     * @param verificationId The ID of the pending phone verification.
+     * @param request The confirmation payload containing the one-time code.
+     * @param completionHandler Called with the confirmed [AccountObjects.PhoneVerification] or a [NetworkingError].
+     */
     fun confirmPhoneVerification(accountId: String, verificationId: String, request: AccountRequests.ConfirmPhoneVerificationRequest, completionHandler: (AccountObjects.PhoneVerification?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.ConfirmPhoneVerification(accountId, verificationId)
@@ -217,6 +373,12 @@ object AccountsAPI {
         }
     }
 
+    /**
+     * Retrieves a Plaid Link token for the given account to initiate a bank-account connection flow.
+     *
+     * @param accountId The ID of the account for which to generate the token.
+     * @param completionHandler Called with the [AccountResponses.PlaidLinkTokenResponse] or a [NetworkingError].
+     */
     fun getPlaidLinkToken(accountId: String, completionHandler: (AccountResponses.PlaidLinkTokenResponse?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = AccountEndpoints.GetPlaidLinkToken(accountId, androidPackageName = "com.framepayments.frame")

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilitiesAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilitiesAPI.kt
@@ -3,8 +3,21 @@ package com.framepayments.framesdk.capabilities
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides coroutine-based and callback-based methods for managing account capabilities.
+ *
+ * All methods require a non-empty [accountId]; calls with an empty ID return `(null, null)`
+ * without making a network request.
+ */
 object CapabilitiesAPI {
     // MARK: Methods using coroutines
+
+    /**
+     * Fetches all capabilities for the given account.
+     *
+     * @param accountId The merchant account ID to retrieve capabilities for.
+     * @return A pair containing the list response on success, or a [NetworkingError] on failure.
+     */
     suspend fun getCapabilities(accountId: String): Pair<CapabilityResponses.ListCapabilitiesResponse?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = CapabilityEndpoints.GetCapabilities(accountId)
@@ -12,6 +25,14 @@ object CapabilitiesAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<CapabilityResponses.ListCapabilitiesResponse>(it) }, error)
     }
 
+    /**
+     * Requests one or more capabilities for the given account.
+     *
+     * @param accountId The merchant account ID to request capabilities for.
+     * @param request The request body specifying which capabilities to enable.
+     * @return A pair containing the list of newly requested [CapabilityObjects.Capability] objects on
+     *   success, or a [NetworkingError] on failure.
+     */
     suspend fun requestCapabilities(accountId: String, request: CapabilityRequests.RequestCapabilitiesRequest): Pair<List<CapabilityObjects.Capability>?, NetworkingError?> {
         if (accountId.isEmpty()) return Pair(null, null)
         val endpoint = CapabilityEndpoints.RequestCapabilities(accountId)
@@ -20,6 +41,14 @@ object CapabilitiesAPI {
         return Pair(decoded, error)
     }
 
+    /**
+     * Fetches a single capability by name for the given account.
+     *
+     * @param accountId The merchant account ID that owns the capability.
+     * @param name The name identifier of the capability to retrieve.
+     * @return A pair containing the [CapabilityObjects.Capability] on success, or a [NetworkingError]
+     *   on failure.
+     */
     suspend fun getCapabilityWith(accountId: String, name: String): Pair<CapabilityObjects.Capability?, NetworkingError?> {
         if (accountId.isEmpty() || name.isEmpty()) return Pair(null, null)
         val endpoint = CapabilityEndpoints.GetCapabilityWith(accountId, name)
@@ -27,6 +56,14 @@ object CapabilitiesAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<CapabilityObjects.Capability>(it) }, error)
     }
 
+    /**
+     * Disables a single capability by name for the given account.
+     *
+     * @param accountId The merchant account ID that owns the capability.
+     * @param name The name identifier of the capability to disable.
+     * @return A pair containing the updated [CapabilityObjects.Capability] on success, or a
+     *   [NetworkingError] on failure.
+     */
     suspend fun disableCapabilityWith(accountId: String, name: String): Pair<CapabilityObjects.Capability?, NetworkingError?> {
         if (accountId.isEmpty() || name.isEmpty()) return Pair(null, null)
         val endpoint = CapabilityEndpoints.DisableCapabilityWith(accountId, name)
@@ -35,6 +72,14 @@ object CapabilitiesAPI {
     }
 
     // MARK: Methods using callbacks
+
+    /**
+     * Fetches all capabilities for the given account and delivers the result via a callback.
+     *
+     * @param accountId The merchant account ID to retrieve capabilities for.
+     * @param completionHandler Invoked with the list response on success, or a [NetworkingError]
+     *   on failure.
+     */
     fun getCapabilities(accountId: String, completionHandler: (CapabilityResponses.ListCapabilitiesResponse?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = CapabilityEndpoints.GetCapabilities(accountId)
@@ -43,6 +88,14 @@ object CapabilitiesAPI {
         }
     }
 
+    /**
+     * Requests one or more capabilities for the given account and delivers the result via a callback.
+     *
+     * @param accountId The merchant account ID to request capabilities for.
+     * @param request The request body specifying which capabilities to enable.
+     * @param completionHandler Invoked with the list of newly requested [CapabilityObjects.Capability]
+     *   objects on success, or a [NetworkingError] on failure.
+     */
     fun requestCapabilities(accountId: String, request: CapabilityRequests.RequestCapabilitiesRequest, completionHandler: (List<CapabilityObjects.Capability>?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty()) return completionHandler(null, null)
         val endpoint = CapabilityEndpoints.RequestCapabilities(accountId)
@@ -51,6 +104,14 @@ object CapabilitiesAPI {
         }
     }
 
+    /**
+     * Fetches a single capability by name for the given account and delivers the result via a callback.
+     *
+     * @param accountId The merchant account ID that owns the capability.
+     * @param name The name identifier of the capability to retrieve.
+     * @param completionHandler Invoked with the [CapabilityObjects.Capability] on success, or a
+     *   [NetworkingError] on failure.
+     */
     fun getCapabilityWith(accountId: String, name: String, completionHandler: (CapabilityObjects.Capability?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty() || name.isEmpty()) return completionHandler(null, null)
         val endpoint = CapabilityEndpoints.GetCapabilityWith(accountId, name)
@@ -59,6 +120,14 @@ object CapabilitiesAPI {
         }
     }
 
+    /**
+     * Disables a single capability by name for the given account and delivers the result via a callback.
+     *
+     * @param accountId The merchant account ID that owns the capability.
+     * @param name The name identifier of the capability to disable.
+     * @param completionHandler Invoked with the updated [CapabilityObjects.Capability] on success, or a
+     *   [NetworkingError] on failure.
+     */
     fun disableCapabilityWith(accountId: String, name: String, completionHandler: (CapabilityObjects.Capability?, NetworkingError?) -> Unit) {
         if (accountId.isEmpty() || name.isEmpty()) return completionHandler(null, null)
         val endpoint = CapabilityEndpoints.DisableCapabilityWith(accountId, name)

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityEndpoints.kt
@@ -3,12 +3,44 @@ package com.framepayments.framesdk.capabilities
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines all network endpoints for the capabilities API.
+ *
+ * Each case maps to a specific HTTP method and URL path under `/v1/accounts/{accountId}/capabilities`.
+ */
 sealed class CapabilityEndpoints : FrameNetworkingEndpoints {
+
+    /**
+     * Retrieves all capabilities for the given account (GET).
+     *
+     * @property accountId The merchant account ID whose capabilities are being fetched.
+     */
     data class GetCapabilities(val accountId: String) : CapabilityEndpoints()
+
+    /**
+     * Requests one or more capabilities for the given account (POST).
+     *
+     * @property accountId The merchant account ID to request capabilities for.
+     */
     data class RequestCapabilities(val accountId: String) : CapabilityEndpoints()
+
+    /**
+     * Retrieves a single capability by name for the given account (GET).
+     *
+     * @property accountId The merchant account ID that owns the capability.
+     * @property name The name identifier of the capability to retrieve.
+     */
     data class GetCapabilityWith(val accountId: String, val name: String) : CapabilityEndpoints()
+
+    /**
+     * Disables a single capability by name for the given account (DELETE).
+     *
+     * @property accountId The merchant account ID that owns the capability.
+     * @property name The name identifier of the capability to disable.
+     */
     data class DisableCapabilityWith(val accountId: String, val name: String) : CapabilityEndpoints()
 
+    /** The relative URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is GetCapabilities -> "/v1/accounts/${this.accountId}/capabilities"
@@ -17,6 +49,7 @@ sealed class CapabilityEndpoints : FrameNetworkingEndpoints {
             is DisableCapabilityWith -> "/v1/accounts/${this.accountId}/capabilities/${this.name}"
         }
 
+    /** The HTTP method for this endpoint (`GET`, `POST`, or `DELETE`). */
     override val httpMethod: String
         get() = when (this) {
             is RequestCapabilities -> "POST"
@@ -24,5 +57,6 @@ sealed class CapabilityEndpoints : FrameNetworkingEndpoints {
             else -> "GET"
         }
 
+    /** Query parameters for this endpoint; always `null` for capability endpoints. */
     override val queryItems: List<QueryItem>? = null
 }

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityObjects.kt
@@ -2,7 +2,18 @@ package com.framepayments.framesdk.capabilities
 
 import com.google.gson.annotations.SerializedName
 
+/** Namespace for data models representing account capability resources. */
 object CapabilityObjects {
+
+    /**
+     * Describes a single outstanding requirement that must be satisfied before a capability can be enabled.
+     *
+     * @property id Unique identifier for this requirement.
+     * @property object The object type string returned by the API (e.g. `"capability_requirement"`).
+     * @property type The category of the requirement (e.g. `"document"`, `"verification"`).
+     * @property status Current fulfillment status of the requirement.
+     * @property source Optional identifier indicating which system or integration raised the requirement.
+     */
     data class CapabilityRequirement(
         val id: String?,
         val `object`: String?,
@@ -11,6 +22,20 @@ object CapabilityObjects {
         val source: String? = null
     )
 
+    /**
+     * Represents a single capability associated with a merchant account.
+     *
+     * @property id Unique identifier for the capability.
+     * @property object The object type string returned by the API (e.g. `"capability"`).
+     * @property name The name identifier of the capability (e.g. `"card_payments"`).
+     * @property accountId The ID of the merchant account that owns this capability.
+     * @property status Current status of the capability (e.g. `"active"`, `"inactive"`, `"pending"`).
+     * @property disabledReason Human-readable explanation of why the capability is disabled, if applicable.
+     * @property currentlyDue List of requirement keys that must be addressed to activate or maintain the capability.
+     * @property created ISO 8601 timestamp when the capability was created.
+     * @property updated ISO 8601 timestamp when the capability was last updated.
+     * @property disabled Whether the capability has been explicitly disabled.
+     */
     data class Capability(
         val id: String?,
         val `object`: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityRequests.kt
@@ -1,6 +1,13 @@
 package com.framepayments.framesdk.capabilities
 
+/** Namespace for request body models used by the capabilities API. */
 object CapabilityRequests {
+
+    /**
+     * Request body for enabling one or more capabilities on a merchant account.
+     *
+     * @property capabilities List of capability name identifiers to request (e.g. `["card_payments"]`).
+     */
     data class RequestCapabilitiesRequest(
         val capabilities: List<String>
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/capabilities/CapabilityResponses.kt
@@ -1,6 +1,13 @@
 package com.framepayments.framesdk.capabilities
 
+/** Namespace for response models returned by the capabilities API. */
 object CapabilityResponses {
+
+    /**
+     * Response model for a paginated list of capabilities associated with a merchant account.
+     *
+     * @property data The list of [CapabilityObjects.Capability] objects returned by the API.
+     */
     data class ListCapabilitiesResponse(
         val data: List<CapabilityObjects.Capability>? = null
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentAPI.kt
@@ -7,8 +7,21 @@ import com.framepayments.framesdk.managers.SiftManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+/**
+ * Provides coroutine-based and callback-based methods for managing charge intents via the Frame API.
+ *
+ * Each operation is available in two flavors: a `suspend` function for use with coroutines and an
+ * overload that accepts a completion handler for callback-based callers.
+ */
 object ChargeIntentAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new charge intent, attaching the current Sonar session ID and live fraud signals before sending.
+     *
+     * @param request The parameters for the charge intent to create.
+     * @return A [Pair] containing the created [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createChargeIntent(request: ChargeIntentsRequests.CreateChargeIntentRequest): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.CreateChargeIntent
         request.sonarSessionId = FrameNetworking.currentSonarSessionId()
@@ -20,6 +33,13 @@ object ChargeIntentAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntent>(data) }, error)
     }
 
+    /**
+     * Captures a previously authorized charge intent for the specified amount.
+     *
+     * @param intentId The ID of the charge intent to capture.
+     * @param request The capture parameters, including the amount in cents to capture.
+     * @return A [Pair] containing the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun captureChargeIntent(intentId: String, request: ChargeIntentsRequests.CaptureChargeIntentRequest): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.CaptureChargeIntent(intentId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -27,6 +47,12 @@ object ChargeIntentAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntent>(data) }, error)
     }
 
+    /**
+     * Confirms a charge intent, triggering payment processing.
+     *
+     * @param intentId The ID of the charge intent to confirm.
+     * @return A [Pair] containing the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun confirmChargeIntent(intentId: String): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.ConfirmChargeIntent(intentId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(null))
@@ -34,30 +60,62 @@ object ChargeIntentAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntent>(data) }, error)
     }
 
+    /**
+     * Cancels a charge intent, preventing it from being confirmed or captured.
+     *
+     * @param intentId The ID of the charge intent to cancel.
+     * @return A [Pair] containing the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun cancelChargeIntent(intentId: String): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.CancelChargeIntent(intentId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(null))
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntent>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of all charge intents for the merchant.
+     *
+     * @param page The 1-based page number to retrieve, or `null` to use the API default.
+     * @param perPage The number of results per page, or `null` to use the API default.
+     * @return A [Pair] containing a [ChargeIntentResponses.ListChargeIntentsResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getAllChargeIntents(page: Int?, perPage: Int?): Pair<ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.GetAllChargeIntents(page = page, perPage = perPage)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntentResponses.ListChargeIntentsResponse>(data) }, error)
     }
 
+    /**
+     * Retrieves a single charge intent by its ID.
+     *
+     * @param intentId The ID of the charge intent to retrieve.
+     * @return A [Pair] containing the [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getChargeIntent(intentId: String): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.GetChargeIntent(intentId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntent>(data) }, error)
     }
 
+    /**
+     * Updates mutable fields on an existing charge intent.
+     *
+     * @param intentId The ID of the charge intent to update.
+     * @param request The fields to update on the charge intent.
+     * @return A [Pair] containing the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateChargeIntent(intentId: String, request: ChargeIntentsRequests.UpdateChargeIntentRequest): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.UpdateChargeIntent(intentId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<ChargeIntent>(data) }, error)
     }
 
+    /**
+     * Voids the uncaptured remainder of a partially captured charge intent.
+     *
+     * @param intentId The ID of the charge intent whose remaining authorized amount should be voided.
+     * @return A [Pair] containing the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     suspend fun voidRemainingChargeIntent(intentId: String): Pair<ChargeIntent?, NetworkingError?> {
         val endpoint = ChargeIntentEndpoints.VoidRemainingChargeIntent(intentId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(null))
@@ -65,6 +123,15 @@ object ChargeIntentAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new charge intent, attaching the current Sonar session ID and live fraud signals before sending.
+     *
+     * Executes the network request on a background thread and delivers the result to [completionHandler].
+     *
+     * @param request The parameters for the charge intent to create.
+     * @param completionHandler Called with the created [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun createChargeIntent(request: ChargeIntentsRequests.CreateChargeIntentRequest, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.CreateChargeIntent
         request.sonarSessionId = FrameNetworking.currentSonarSessionId()
@@ -76,6 +143,13 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Captures a previously authorized charge intent for the specified amount.
+     *
+     * @param intentId The ID of the charge intent to capture.
+     * @param request The capture parameters, including the amount in cents to capture.
+     * @param completionHandler Called with the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun captureChargeIntent(intentId: String, request: ChargeIntentsRequests.CaptureChargeIntentRequest, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.CaptureChargeIntent(intentId)
 
@@ -84,6 +158,12 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Confirms a charge intent, triggering payment processing.
+     *
+     * @param intentId The ID of the charge intent to confirm.
+     * @param completionHandler Called with the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun confirmChargeIntent(intentId: String, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.ConfirmChargeIntent(intentId)
 
@@ -92,6 +172,12 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Cancels a charge intent, preventing it from being confirmed or captured.
+     *
+     * @param intentId The ID of the charge intent to cancel.
+     * @param completionHandler Called with the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun cancelChargeIntent(intentId: String, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.CancelChargeIntent(intentId)
 
@@ -100,6 +186,13 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of all charge intents for the merchant.
+     *
+     * @param page The 1-based page number to retrieve, or `null` to use the API default.
+     * @param perPage The number of results per page, or `null` to use the API default.
+     * @param completionHandler Called with a [ChargeIntentResponses.ListChargeIntentsResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getAllChargeIntents(page: Int?, perPage: Int?, completionHandler: (ChargeIntentResponses.ListChargeIntentsResponse?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.GetAllChargeIntents(page = page, perPage = perPage)
 
@@ -108,6 +201,12 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Retrieves a single charge intent by its ID.
+     *
+     * @param intentId The ID of the charge intent to retrieve.
+     * @param completionHandler Called with the [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun getChargeIntent(intentId: String, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.GetChargeIntent(intentId)
 
@@ -116,6 +215,13 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Updates mutable fields on an existing charge intent.
+     *
+     * @param intentId The ID of the charge intent to update.
+     * @param request The fields to update on the charge intent.
+     * @param completionHandler Called with the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun updateChargeIntent(intentId: String, request: ChargeIntentsRequests.UpdateChargeIntentRequest, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.UpdateChargeIntent(intentId)
 
@@ -124,6 +230,12 @@ object ChargeIntentAPI {
         }
     }
 
+    /**
+     * Voids the uncaptured remainder of a partially captured charge intent.
+     *
+     * @param intentId The ID of the charge intent whose remaining authorized amount should be voided.
+     * @param completionHandler Called with the updated [ChargeIntent] on success, or a [NetworkingError] on failure.
+     */
     fun voidRemainingChargeIntent(intentId: String, completionHandler: (ChargeIntent?, NetworkingError?) -> Unit) {
         val endpoint = ChargeIntentEndpoints.VoidRemainingChargeIntent(intentId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentEndpoints.kt
@@ -2,16 +2,69 @@ package com.framepayments.framesdk.chargeintents
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines every API endpoint used to manage charge intents.
+ *
+ * Each case carries the data required to build its URL, HTTP method, and query parameters.
+ * Implement [FrameNetworkingEndpoints] so the networking layer can dispatch requests uniformly.
+ */
 sealed class ChargeIntentEndpoints : FrameNetworkingEndpoints {
+
+    /** Creates a new charge intent (`POST /v1/charge_intents`). */
     object CreateChargeIntent : ChargeIntentEndpoints()
+
+    /**
+     * Retrieves a single charge intent by ID (`GET /v1/charge_intents/{intentId}`).
+     *
+     * @property intentId The ID of the charge intent to retrieve.
+     */
     data class GetChargeIntent(val intentId: String) : ChargeIntentEndpoints()
+
+    /**
+     * Retrieves a paginated list of all charge intents (`GET /v1/charge_intents`).
+     *
+     * @property perPage Number of results to return per page, or `null` to use the API default.
+     * @property page 1-based page number to retrieve, or `null` to use the API default.
+     */
     data class GetAllChargeIntents(val perPage: Int?, val page: Int?) : ChargeIntentEndpoints()
+
+    /**
+     * Updates an existing charge intent (`PATCH /v1/charge_intents/{intentId}`).
+     *
+     * @property intentId The ID of the charge intent to update.
+     */
     data class UpdateChargeIntent(val intentId: String) : ChargeIntentEndpoints()
+
+    /**
+     * Captures an authorized charge intent (`POST /v1/charge_intents/{intentId}/capture`).
+     *
+     * @property intentId The ID of the charge intent to capture.
+     */
     data class CaptureChargeIntent(val intentId: String) : ChargeIntentEndpoints()
+
+    /**
+     * Confirms a charge intent, triggering payment processing (`POST /v1/charge_intents/{intentId}/confirm`).
+     *
+     * @property intentId The ID of the charge intent to confirm.
+     */
     data class ConfirmChargeIntent(val intentId: String) : ChargeIntentEndpoints()
+
+    /**
+     * Cancels a charge intent before it is captured (`POST /v1/charge_intents/{intentId}/cancel`).
+     *
+     * @property intentId The ID of the charge intent to cancel.
+     */
     data class CancelChargeIntent(val intentId: String) : ChargeIntentEndpoints()
+
+    /**
+     * Voids the uncaptured remainder of a partially captured charge intent
+     * (`POST /v1/charge_intents/{intentId}/void_remaining`).
+     *
+     * @property intentId The ID of the charge intent whose remaining authorized amount should be voided.
+     */
     data class VoidRemainingChargeIntent(val intentId: String) : ChargeIntentEndpoints()
 
+    /** Returns the relative URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is CreateChargeIntent, is GetAllChargeIntents ->
@@ -30,6 +83,7 @@ sealed class ChargeIntentEndpoints : FrameNetworkingEndpoints {
                 "/v1/charge_intents/${this.intentId}/void_remaining"
         }
 
+    /** Returns the HTTP method string for this endpoint. */
     override val httpMethod: String
         get() = when (this) {
             is CreateChargeIntent, is CancelChargeIntent, is CaptureChargeIntent,
@@ -38,6 +92,7 @@ sealed class ChargeIntentEndpoints : FrameNetworkingEndpoints {
             else -> "GET"
         }
 
+    /** Returns the URL query parameters for this endpoint, or `null` if none apply. */
     override val queryItems: List<QueryItem>?
         get() = when (this) {
             is GetAllChargeIntents -> {

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentObjects.kt
@@ -2,22 +2,65 @@ package com.framepayments.framesdk.chargeintents
 import com.framepayments.framesdk.FrameObjects
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Controls when the authorized funds are captured after a charge intent is confirmed.
+ */
 enum class AuthorizationMode {
+    /** Captures funds immediately when the charge intent is confirmed. */
     @SerializedName("automatic") AUTOMATIC,
+
+    /** Holds the authorized amount for later manual capture. */
     @SerializedName("manual") MANUAL
 }
 
+/**
+ * Represents the lifecycle state of a charge intent.
+ */
 enum class ChargeIntentStatus {
+    /** The charge intent was canceled before completion. */
     @SerializedName("canceled") CANCELED,
+
+    /** The charge has been disputed by the customer. */
     @SerializedName("disputed") DISPUTED,
+
+    /** The payment attempt failed. */
     @SerializedName("failed") FAILED,
+
+    /** The charge intent has been created but not yet confirmed. */
     @SerializedName("incomplete") INCOMPLETE,
+
+    /** The charge intent is awaiting processing. */
     @SerializedName("pending") PENDING,
+
+    /** The charge has been fully refunded. */
     @SerializedName("refunded") REFUNDED,
+
+    /** The authorization was reversed before capture. */
     @SerializedName("reversed") REVERSED,
+
+    /** The charge was successfully completed. */
     @SerializedName("succeeded") SUCCEEDED
 }
 
+/**
+ * Represents a charge intent returned by the Frame API.
+ *
+ * @property id Unique identifier for the charge intent.
+ * @property currency Three-letter ISO 4217 currency code.
+ * @property customer The customer associated with this charge intent.
+ * @property shipping The shipping address for the order.
+ * @property status Current lifecycle status of the charge intent.
+ * @property description Merchant-supplied description of the charge.
+ * @property amount Total amount in the smallest currency unit (e.g., cents).
+ * @property created Unix timestamp of when the charge intent was created.
+ * @property updated Unix timestamp of when the charge intent was last updated.
+ * @property livemode `true` if this charge intent was created in live mode; `false` for test mode.
+ * @property latestCharge The most recent charge attempt associated with this intent.
+ * @property paymentMethod The payment method attached to this charge intent.
+ * @property authorizationMode Whether funds are captured automatically or held for manual capture.
+ * @property failureDescription Human-readable explanation of why the charge intent failed, if applicable.
+ * @property intentObject The object type identifier returned by the API (typically `"charge_intent"`).
+ */
 data class ChargeIntent(
     val id: String?,
     val currency: String?,
@@ -36,6 +79,28 @@ data class ChargeIntent(
     @SerializedName("object") val intentObject: String?
 )
 
+/**
+ * Represents the most recent charge attempt made against a charge intent.
+ *
+ * @property id Unique identifier for the charge.
+ * @property currency Three-letter ISO 4217 currency code.
+ * @property created Unix timestamp of when the charge was created.
+ * @property updated Unix timestamp of when the charge was last updated.
+ * @property livemode `true` if this charge was created in live mode; `false` for test mode.
+ * @property captured `true` if the authorized funds have been captured.
+ * @property disputed `true` if the customer has opened a dispute on this charge.
+ * @property refunded `true` if the charge has been refunded.
+ * @property description Merchant-supplied description of the charge.
+ * @property status Current lifecycle status of the charge.
+ * @property customer ID of the customer associated with this charge.
+ * @property amount Total charge amount in the smallest currency unit (e.g., cents).
+ * @property failureMessage Human-readable explanation of why the charge failed, if applicable.
+ * @property paymentMethodDetails Full details of the payment method used for this charge.
+ * @property paymentMethod ID of the payment method used for this charge.
+ * @property chargeIntent ID of the parent charge intent.
+ * @property amountCaptured Amount that has been captured, in the smallest currency unit.
+ * @property amountRefunded Amount that has been refunded, in the smallest currency unit.
+ */
 data class LatestCharge (
     val id: String?,
     val currency : String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentRequests.kt
@@ -2,11 +2,36 @@ package com.framepayments.framesdk.chargeintents
 import com.framepayments.framesdk.FrameObjects
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains request body models used when creating, updating, and capturing charge intents.
+ */
 object ChargeIntentsRequests {
+
+    /**
+     * Identifies the type of payment method supplied in a request.
+     */
     enum class PaymentMethodType {
+        /** A card payment method. */
         card
     }
 
+    /**
+     * Request body for creating a new charge intent.
+     *
+     * @property amount Charge amount in the smallest currency unit (e.g., cents).
+     * @property currency Three-letter ISO 4217 currency code.
+     * @property customer ID of an existing customer to associate with this charge intent, or `null`.
+     * @property description Merchant-supplied description of the charge.
+     * @property confirm `true` to confirm and process the charge intent immediately upon creation.
+     * @property paymentMethod ID of an existing payment method to attach to the charge intent, or `null`.
+     * @property receiptEmail Email address to send a receipt to upon successful payment, or `null`.
+     * @property authorizationMode Whether to capture funds automatically or hold them for manual capture.
+     * @property customerData Inline customer name and email to create or match a customer record, or `null`.
+     * @property paymentMethodData Inline card details used to create a new payment method, or `null`.
+     * @property fraudSignals Device fraud signals attached automatically by the SDK before the request is sent.
+     * @property useFrameSDK Indicates the request originated from the Frame Android SDK; defaults to `true`.
+     * @property sonarSessionId Session identifier from the Sonar fraud-detection service, attached automatically by the SDK.
+     */
     data class CreateChargeIntentRequest (
         val amount: Int,
         val currency : String,
@@ -23,6 +48,17 @@ object ChargeIntentsRequests {
         @SerializedName("sonar_session_id") var sonarSessionId: String? = null
     )
 
+    /**
+     * Request body for updating mutable fields on an existing charge intent.
+     *
+     * @property amount Updated charge amount in the smallest currency unit, or `null` to leave unchanged.
+     * @property currency Updated three-letter ISO 4217 currency code, or `null` to leave unchanged.
+     * @property customer Updated customer ID, or `null` to leave unchanged.
+     * @property description Updated merchant-supplied description, or `null` to leave unchanged.
+     * @property confirm `true` to confirm the charge intent as part of this update, or `null` to leave unchanged.
+     * @property paymentMethod Updated payment method ID, or `null` to leave unchanged.
+     * @property receiptEmail Updated receipt email address, or `null` to leave unchanged.
+     */
     data class UpdateChargeIntentRequest (
         val amount: Int?,
         val currency: String?,
@@ -33,15 +69,37 @@ object ChargeIntentsRequests {
         @SerializedName("receipt_email") val receiptEmail: String?
     )
 
+    /**
+     * Request body for capturing an authorized charge intent.
+     *
+     * @property amountCapturedCents The amount to capture, in cents. Must not exceed the authorized amount.
+     */
     data class CaptureChargeIntentRequest(
         @SerializedName("amount_captured_cents") val amountCapturedCents: Int
     )
 
+    /**
+     * Inline customer data used to create or match a customer record during charge intent creation.
+     *
+     * @property name Full name of the customer.
+     * @property email Email address of the customer.
+     */
     data class CustomerData (
         val name: String,
         val email: String
     )
 
+    /**
+     * Inline card details used to create a new payment method during charge intent creation.
+     *
+     * @property attach `true` to attach the resulting payment method to the customer for future use.
+     * @property type The type of payment method being provided.
+     * @property cardNumber The card number.
+     * @property expMonth Two-digit expiration month (e.g., `"01"` for January).
+     * @property expYear Four-digit expiration year (e.g., `"2027"`).
+     * @property cvc The card verification code.
+     * @property billing Billing address associated with the card, or `null`.
+     */
     data class PaymentMethodData (
         val attach: Boolean?,
         val type: PaymentMethodType,
@@ -52,6 +110,11 @@ object ChargeIntentsRequests {
         val billing: FrameObjects.BillingAddress?
     )
 
+    /**
+     * Device-level fraud signals collected by the SDK and attached to charge intent requests.
+     *
+     * @property clientIp The public IP address of the device initiating the request.
+     */
     data class FraudSignals (
         @SerializedName("client_ip") val clientIp: String?
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/chargeintents/ChargeIntentResponses.kt
@@ -1,7 +1,17 @@
 package com.framepayments.framesdk.chargeintents
 import com.framepayments.framesdk.FrameMetadata
 
+/**
+ * Contains response body models returned by charge intent API calls.
+ */
 object ChargeIntentResponses {
+
+    /**
+     * Response body for a paginated list of charge intents.
+     *
+     * @property meta Pagination metadata for the result set, or `null` if unavailable.
+     * @property data The list of charge intents on the current page, or `null` if the response contains no results.
+     */
     data class ListChargeIntentsResponse (
         val meta: FrameMetadata?,
         val data: List<ChargeIntent>?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/ConfigurationAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/ConfigurationAPI.kt
@@ -1,8 +1,21 @@
 package com.framepayments.framesdk.configurations
 import com.framepayments.framesdk.FrameNetworking
 
+/**
+ * Fetches and caches third-party service configurations from the Frame API.
+ *
+ * Each method retrieves a configuration object from the network, persists it to
+ * [SecureConfigurationStorage], and returns the parsed response. Both coroutine
+ * (suspend) and callback variants are provided for each service.
+ */
 object ConfigurationAPI {
     //MARK: Methods using coroutines
+    /**
+     * Fetches the Evervault configuration from the API and caches it locally.
+     *
+     * @return The parsed [ConfigurationResponses.GetEvervaultConfigurationResponse], or `null` if
+     *   the request fails or the response cannot be parsed.
+     */
     suspend fun getEvervaultConfiguration(): ConfigurationResponses.GetEvervaultConfigurationResponse? {
         val endpoint = ConfigurationEndpoints.GetEvervaultConfiguration
         val (data, _) = FrameNetworking.performDataTask(endpoint)
@@ -22,6 +35,12 @@ object ConfigurationAPI {
         return null
     }
 
+    /**
+     * Fetches the Sift configuration from the API and caches it locally.
+     *
+     * @return The parsed [ConfigurationResponses.GetSiftConfigurationResponse], or `null` if the
+     *   request fails or the response cannot be parsed.
+     */
     suspend fun getSiftConfiguration(): ConfigurationResponses.GetSiftConfigurationResponse? {
         val endpoint = ConfigurationEndpoints.GetSiftConfiguration
         val (data, _) = FrameNetworking.performDataTask(endpoint)
@@ -42,6 +61,14 @@ object ConfigurationAPI {
     }
 
     //MARK: Methods using callbacks
+    /**
+     * Fetches the Evervault configuration from the API and caches it locally, delivering the
+     * result via a callback.
+     *
+     * @param completionHandler Invoked with the parsed
+     *   [ConfigurationResponses.GetEvervaultConfigurationResponse], or `null` if the request fails
+     *   or the response cannot be parsed.
+     */
     fun getEvervaultConfiguration(completionHandler: (ConfigurationResponses.GetEvervaultConfigurationResponse?) -> Unit) {
         val endpoint = ConfigurationEndpoints.GetEvervaultConfiguration
 
@@ -63,6 +90,14 @@ object ConfigurationAPI {
         }
     }
 
+    /**
+     * Fetches the Sift configuration from the API and caches it locally, delivering the result
+     * via a callback.
+     *
+     * @param completionHandler Invoked with the parsed
+     *   [ConfigurationResponses.GetSiftConfigurationResponse], or `null` if the request fails or
+     *   the response cannot be parsed.
+     */
     fun getSiftConfiguration(completionHandler: (ConfigurationResponses.GetSiftConfigurationResponse?) -> Unit) {
         val endpoint = ConfigurationEndpoints.GetSiftConfiguration
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/ConfigurationEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/ConfigurationEndpoints.kt
@@ -3,8 +3,14 @@ package com.framepayments.framesdk.configurations
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints used to retrieve third-party service configurations.
+ */
 sealed class ConfigurationEndpoints : FrameNetworkingEndpoints {
+    /** Requests the Evervault configuration from `GET /v1/config/evervault`. */
     object GetEvervaultConfiguration : ConfigurationEndpoints()
+
+    /** Requests the Sift configuration from `GET /v1/config/sift`. */
     object GetSiftConfiguration: ConfigurationEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/ConfigurationResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/ConfigurationResponses.kt
@@ -2,12 +2,25 @@ package com.framepayments.framesdk.configurations
 
 import com.google.gson.annotations.SerializedName
 
+/** Contains response models for configuration API calls. */
 object ConfigurationResponses {
+    /**
+     * Holds the Evervault credentials returned by the configuration endpoint.
+     *
+     * @property appId The Evervault application identifier.
+     * @property teamId The Evervault team identifier.
+     */
     data class GetEvervaultConfigurationResponse(
         @SerializedName("app_id") val appId: String? = null,
         @SerializedName("team_id") val teamId: String? = null
     )
 
+    /**
+     * Holds the Sift credentials returned by the configuration endpoint.
+     *
+     * @property accountId The Sift account identifier.
+     * @property beaconKey The Sift beacon key used for device fingerprinting.
+     */
     data class GetSiftConfigurationResponse(
         @SerializedName("account_id") val accountId: String? = null,
         @SerializedName("beacon_key") val beaconKey: String? = null

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/SecureConfigurationStorage.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/configurations/SecureConfigurationStorage.kt
@@ -8,9 +8,22 @@ import androidx.core.content.edit
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 
+/**
+ * Provides encrypted persistent storage for SDK configuration values using
+ * [EncryptedSharedPreferences] backed by AES256-GCM keys.
+ *
+ * All values are serialized to JSON before encryption and deserialized on retrieval, so any
+ * serializable type can be stored.
+ */
 object SecureConfigurationStorage {
     private const val PREFS_NAME = "config_store_encrypted"
 
+    /**
+     * Returns an [EncryptedSharedPreferences] instance backed by an AES256-GCM master key.
+     *
+     * @param context The Android context used to access the application's key store and storage.
+     * @return A [SharedPreferences] whose keys and values are encrypted at rest.
+     */
     fun prefs(context: Context): SharedPreferences {
         val appContext = context.applicationContext
         val masterKey = MasterKey.Builder(appContext)
@@ -25,20 +38,49 @@ object SecureConfigurationStorage {
         )
     }
 
+    /**
+     * Serializes [value] to JSON and writes it to encrypted storage under [key].
+     *
+     * @param T The type of the value to store.
+     * @param context The Android context used to access encrypted storage.
+     * @param key The storage key under which the value is saved.
+     * @param value The value to serialize and persist.
+     */
     fun <T> save(context: Context, key: String, value: T) {
         val json = Gson().toJson(value)
         prefs(context).edit { putString(key, json) }
     }
 
+    /**
+     * Reads and deserializes the value stored under [key] into type [T].
+     *
+     * @param T The expected type to deserialize the stored JSON into.
+     * @param context The Android context used to access encrypted storage.
+     * @param key The storage key to look up.
+     * @return The deserialized value, or `null` if the key is absent or deserialization fails.
+     */
     inline fun <reified T> retrieve(context: Context, key: String): T? {
         val json = prefs(context).getString(key, null) ?: return null
         val type = object : TypeToken<T>() {}.type
         return runCatching { Gson().fromJson<T>(json, type) }.getOrNull()
     }
 
+    /**
+     * Reads the raw encrypted JSON string stored under [key] without deserializing it.
+     *
+     * @param context The Android context used to access encrypted storage.
+     * @param key The storage key to look up.
+     * @return The raw JSON string, or `null` if the key is absent.
+     */
     fun getRaw(context: Context, key: String): String? =
         prefs(context).getString(key, null)
 
+    /**
+     * Removes the entry stored under [key] from encrypted storage.
+     *
+     * @param context The Android context used to access encrypted storage.
+     * @param key The storage key to remove.
+     */
     fun remove(context: Context, key: String) {
         prefs(context).edit { remove(key) }
     }

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityAPI.kt
@@ -4,32 +4,78 @@ import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 import com.framepayments.framesdk.FileUpload
 
+/**
+ * Provides API operations for creating, retrieving, and verifying customer identity records.
+ *
+ * Each operation is available as both a coroutine suspend function and a callback-based overload.
+ * "Customer" refers to the merchant's end user whose identity is being verified.
+ */
 object CustomerIdentityAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new customer identity verification record with the supplied PII.
+     *
+     * @param request The request body containing the customer's personal information required
+     *   to initiate identity verification.
+     * @return A [Pair] where the first element is the created [CustomerIdentity] on success,
+     *   and the second element is a [NetworkingError] on failure; one of the two will be null.
+     */
     suspend fun createCustomerIdentity(request: CustomerIdentityRequests.CreateCustomerIdentityRequest): Pair<CustomerIdentity?, NetworkingError?> {
         val endpoint = CustomerIdentityEndpoints.CreateCustomerIdentity
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<CustomerIdentity>(data) }, error)
     }
 
+    /**
+     * Retrieves an existing customer identity verification record by its identifier.
+     *
+     * @param customerIdentityId The unique identifier of the customer identity record to retrieve.
+     * @return A [Pair] where the first element is the matching [CustomerIdentity] on success,
+     *   and the second element is a [NetworkingError] on failure; one of the two will be null.
+     */
     suspend fun getCustomerIdentityWith(customerIdentityId: String): Pair<CustomerIdentity?, NetworkingError?> {
         val endpoint = CustomerIdentityEndpoints.GetCustomerIdentityWith(customerIdentityId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<CustomerIdentity>(data) }, error)
     }
 
+    /**
+     * Creates a new identity verification record attached to an existing customer.
+     *
+     * @param customerId The unique identifier of the existing customer to associate with the
+     *   new identity verification record.
+     * @return A [Pair] where the first element is the created [CustomerIdentity] on success,
+     *   and the second element is a [NetworkingError] on failure; one of the two will be null.
+     */
     suspend fun createCustomerIdentityWith(customerId: String): Pair<CustomerIdentity?, NetworkingError?> {
         val endpoint = CustomerIdentityEndpoints.CreateCustomerIdentityWith(customerId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<CustomerIdentity>(data) }, error)
     }
 
+    /**
+     * Submits an existing customer identity record for KYC/identity verification processing.
+     *
+     * @param customerIdentityId The unique identifier of the customer identity record to submit.
+     * @return A [Pair] where the first element is the updated [CustomerIdentity] on success,
+     *   and the second element is a [NetworkingError] on failure; one of the two will be null.
+     */
     suspend fun submitForVerification(customerIdentityId: String): Pair<CustomerIdentity?, NetworkingError?> {
         val endpoint = CustomerIdentityEndpoints.SubmitForVerification(customerIdentityId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<CustomerIdentity>(data) }, error)
     }
 
+    /**
+     * Uploads identity document files for a customer identity record via a multipart request.
+     *
+     * @param customerIdentityId The unique identifier of the customer identity record to attach
+     *   the documents to.
+     * @param filesToUpload The list of [FileUpload] objects representing the document files to send.
+     * @return A [Pair] where the first element is the updated [CustomerIdentity] on success,
+     *   and the second element is a [NetworkingError] on failure; one of the two will be null.
+     */
     suspend fun uploadIdentityDocuments(customerIdentityId: String, filesToUpload: List<FileUpload>): Pair<CustomerIdentity?, NetworkingError?> {
         val endpoint = CustomerIdentityEndpoints.UploadIdentityDocuments(customerIdentityId)
         val (data, error) = FrameNetworking.performMultipartDataTask(endpoint, filesToUpload)
@@ -37,6 +83,16 @@ object CustomerIdentityAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new customer identity verification record with the supplied PII and delivers
+     * the result to the provided callback.
+     *
+     * @param request The request body containing the customer's personal information required
+     *   to initiate identity verification.
+     * @param completionHandler Invoked with the created [CustomerIdentity] on success, or a
+     *   [NetworkingError] on failure; one of the two arguments will be null.
+     */
     fun createCustomerIdentity(request: CustomerIdentityRequests.CreateCustomerIdentityRequest, completionHandler: (CustomerIdentity?, NetworkingError?) -> Unit) {
         val endpoint = CustomerIdentityEndpoints.CreateCustomerIdentity
 
@@ -45,6 +101,14 @@ object CustomerIdentityAPI {
         }
     }
 
+    /**
+     * Retrieves an existing customer identity verification record by its identifier and delivers
+     * the result to the provided callback.
+     *
+     * @param customerIdentityId The unique identifier of the customer identity record to retrieve.
+     * @param completionHandler Invoked with the matching [CustomerIdentity] on success, or a
+     *   [NetworkingError] on failure; one of the two arguments will be null.
+     */
     fun getCustomerIdentityWith(customerIdentityId: String, completionHandler: (CustomerIdentity?, NetworkingError?) -> Unit) {
         val endpoint = CustomerIdentityEndpoints.GetCustomerIdentityWith(customerIdentityId)
 
@@ -53,6 +117,15 @@ object CustomerIdentityAPI {
         }
     }
 
+    /**
+     * Creates a new identity verification record attached to an existing customer and delivers
+     * the result to the provided callback.
+     *
+     * @param customerId The unique identifier of the existing customer to associate with the
+     *   new identity verification record.
+     * @param completionHandler Invoked with the created [CustomerIdentity] on success, or a
+     *   [NetworkingError] on failure; one of the two arguments will be null.
+     */
     fun createCustomerIdentityWith(customerId: String, completionHandler: (CustomerIdentity?, NetworkingError?) -> Unit) {
         val endpoint = CustomerIdentityEndpoints.CreateCustomerIdentityWith(customerId)
         FrameNetworking.performDataTask(endpoint) { data, error ->
@@ -60,6 +133,14 @@ object CustomerIdentityAPI {
         }
     }
 
+    /**
+     * Submits an existing customer identity record for KYC/identity verification processing
+     * and delivers the result to the provided callback.
+     *
+     * @param customerIdentityId The unique identifier of the customer identity record to submit.
+     * @param completionHandler Invoked with the updated [CustomerIdentity] on success, or a
+     *   [NetworkingError] on failure; one of the two arguments will be null.
+     */
     fun submitForVerification(customerIdentityId: String, completionHandler: (CustomerIdentity?, NetworkingError?) -> Unit) {
         val endpoint = CustomerIdentityEndpoints.SubmitForVerification(customerIdentityId)
         FrameNetworking.performDataTask(endpoint) { data, error ->
@@ -67,6 +148,16 @@ object CustomerIdentityAPI {
         }
     }
 
+    /**
+     * Uploads identity document files for a customer identity record via a multipart request
+     * and delivers the result to the provided callback.
+     *
+     * @param customerIdentityId The unique identifier of the customer identity record to attach
+     *   the documents to.
+     * @param filesToUpload The list of [FileUpload] objects representing the document files to send.
+     * @param completionHandler Invoked with the updated [CustomerIdentity] on success, or a
+     *   [NetworkingError] on failure; one of the two arguments will be null.
+     */
     fun uploadIdentityDocuments(customerIdentityId: String, filesToUpload: List<FileUpload>, completionHandler: (CustomerIdentity?, NetworkingError?) -> Unit) {
         val endpoint = CustomerIdentityEndpoints.UploadIdentityDocuments(customerIdentityId)
         FrameNetworking.performMultipartDataTask(endpoint, filesToUpload) { data, error ->

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityEndpoints.kt
@@ -3,11 +3,55 @@ package com.framepayments.framesdk.customeridentity
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints used by customer identity verification operations.
+ *
+ * Each case maps to a specific HTTP method and URL path used by [CustomerIdentityAPI].
+ */
 sealed class CustomerIdentityEndpoints : FrameNetworkingEndpoints {
+
+    /**
+     * Endpoint for creating a new customer identity verification record.
+     *
+     * Sends a POST request to `/v1/customer_identity_verifications`.
+     */
     object CreateCustomerIdentity : CustomerIdentityEndpoints()
+
+    /**
+     * Endpoint for retrieving an existing customer identity verification record.
+     *
+     * Sends a GET request to `/v1/customer_identity_verifications/{customerIdentityId}`.
+     *
+     * @property customerIdentityId The unique identifier of the identity record to retrieve.
+     */
     data class GetCustomerIdentityWith(val customerIdentityId: String) : CustomerIdentityEndpoints()
+
+    /**
+     * Endpoint for creating a new identity verification record attached to an existing customer.
+     *
+     * Sends a POST request to `/v1/customers/{customerId}/identity_verifications`.
+     *
+     * @property customerId The unique identifier of the existing customer to link the record to.
+     */
     data class CreateCustomerIdentityWith(val customerId: String) : CustomerIdentityEndpoints()
+
+    /**
+     * Endpoint for submitting an identity verification record for KYC processing.
+     *
+     * Sends a POST request to `/v1/customer_identity_verifications/{customerIdentityId}/submit`.
+     *
+     * @property customerIdentityId The unique identifier of the identity record to submit.
+     */
     data class SubmitForVerification(val customerIdentityId: String) : CustomerIdentityEndpoints()
+
+    /**
+     * Endpoint for uploading identity document files to a verification record.
+     *
+     * Sends a multipart POST request to
+     * `/v1/customer_identity_verifications/{customerIdentityId}/upload_documents`.
+     *
+     * @property customerIdentityId The unique identifier of the identity record to attach documents to.
+     */
     data class UploadIdentityDocuments(val customerIdentityId: String) : CustomerIdentityEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityObjects.kt
@@ -2,24 +2,59 @@ package com.framepayments.framesdk.customeridentity
 import com.google.gson.annotations.SerializedName
 import com.framepayments.framesdk.FrameObjects
 
+/**
+ * Represents the overall verification state of a customer identity record.
+ */
 enum class CustomerIdentityStatus {
+    /** The identity record is missing required information and has not been submitted. */
     @SerializedName("incomplete") INCOMPLETE,
+
+    /** The identity record has been submitted and is awaiting verification. */
     @SerializedName("pending") PENDING,
+
+    /** The identity record has been successfully verified. */
     @SerializedName("verified") VERIFIED,
+
+    /** The identity verification attempt has failed. */
     @SerializedName("failed") FAILED
 }
 
+/**
+ * Represents the outcome of an individual verification check performed on an identity document.
+ */
 enum class VerificationCheckStatus {
+    /** The verification check passed successfully. */
     @SerializedName("passed") PASSED,
+
+    /** The verification check did not pass. */
     @SerializedName("failed") FAILED
 }
 
+/**
+ * Tracks which identity document files have been attached to a customer identity record.
+ *
+ * @property frontDocumentAttached Whether the front side of the identity document has been uploaded.
+ * @property backDocumentAttached Whether the back side of the identity document has been uploaded.
+ * @property selfieAttached Whether a selfie image has been uploaded.
+ */
 data class IdentificationDocuments(
     @SerializedName("front_document_attached") val frontDocumentAttached: Boolean?,
     @SerializedName("back_document_attached") val backDocumentAttached: Boolean?,
     @SerializedName("selfie_attached") val selfieAttached: Boolean?
 )
 
+/**
+ * Contains personal data extracted from the customer's identity document during verification.
+ *
+ * @property firstName The customer's first name as it appears on the document.
+ * @property lastName The customer's last name as it appears on the document.
+ * @property middleName The customer's middle name as it appears on the document, if present.
+ * @property dateOfBirth The customer's date of birth extracted from the document.
+ * @property licenseNumber The driver's license or ID number found on the document.
+ * @property state The issuing state of the identity document.
+ * @property expirationDate The expiration date of the identity document.
+ * @property address The address printed on the identity document.
+ */
 data class IdentificationData(
     @SerializedName("first_name") val firstName: String?,
     @SerializedName("last_name") val lastName: String?,
@@ -31,6 +66,14 @@ data class IdentificationData(
     val address: String?
 )
 
+/**
+ * Holds the results of individual automated checks performed on the customer's identity document.
+ *
+ * @property idPhotoFaceMatch The result of comparing the document photo against the customer's selfie.
+ * @property idAgeOver18 The result of verifying that the customer is 18 years of age or older.
+ * @property idNotExpired The result of checking that the identity document has not expired.
+ * @property idTamperDetection The result of checking the document for signs of tampering.
+ */
 data class VerificationChecks(
     @SerializedName("id_photo_face_match") val idPhotoFaceMatch: VerificationCheckStatus?,
     @SerializedName("id_age_over_18") val idAgeOver18: VerificationCheckStatus?,
@@ -38,6 +81,25 @@ data class VerificationChecks(
     @SerializedName("id_tamper_detection") val idTamperDetection: VerificationCheckStatus?
 )
 
+/**
+ * Represents a customer identity verification record returned by the Frame API.
+ *
+ * @property id The unique identifier for this identity verification record.
+ * @property status The current overall status of the identity verification.
+ * @property created Unix timestamp (seconds) indicating when the record was created.
+ * @property updated Unix timestamp (seconds) indicating when the record was last updated.
+ * @property pending Unix timestamp (seconds) indicating when the record entered the pending state.
+ * @property verified Unix timestamp (seconds) indicating when the record was verified, if applicable.
+ * @property failed Unix timestamp (seconds) indicating when the record entered the failed state, if applicable.
+ * @property verificationURL A URL the customer can visit to complete the identity verification flow.
+ * @property identityObject The API object type identifier for this resource.
+ * @property documents The attachment status of the customer's identity document files.
+ * @property provider The identity verification provider used to process this record.
+ * @property providerReference The external reference identifier assigned by the verification provider.
+ * @property extractedData Personal data extracted from the customer's identity document by the provider.
+ * @property verificationChecks The results of automated checks performed on the identity document.
+ * @property customer The Frame customer object associated with this identity record, if linked.
+ */
 data class CustomerIdentity(
     val id: String?,
     val status: CustomerIdentityStatus?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customeridentity/CustomerIdentityRequests.kt
@@ -3,7 +3,24 @@ package com.framepayments.framesdk.customeridentity
 import com.google.gson.annotations.SerializedName
 import com.framepayments.framesdk.FrameObjects
 
+/**
+ * Contains request model types used by customer identity API operations.
+ */
 object CustomerIdentityRequests {
+
+    /**
+     * The request body required to create a new customer identity verification record.
+     *
+     * All fields are required by the API; none may be omitted.
+     *
+     * @property address The customer's billing address.
+     * @property firstName The customer's first name.
+     * @property lastName The customer's last name.
+     * @property dateOfBirth The customer's date of birth in `YYYY-MM-DD` format.
+     * @property phoneNumber The customer's phone number.
+     * @property email The customer's email address.
+     * @property ssn The customer's Social Security Number.
+     */
     data class CreateCustomerIdentityRequest(
         val address: FrameObjects.BillingAddress,
         @SerializedName("first_name") val firstName: String,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomerEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomerEndpoints.kt
@@ -3,16 +3,72 @@ package com.framepayments.framesdk.customers
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines all HTTP endpoints used by the customers API.
+ *
+ * Each case maps to a distinct API route and HTTP method. Construct the appropriate case
+ * and pass it to [com.framepayments.framesdk.FrameNetworking] to execute the request.
+ */
 sealed class CustomerEndpoints : FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new customer via POST /v1/customers. */
     object CreateCustomer: CustomerEndpoints()
+
+    /**
+     * Endpoint for updating an existing customer via PATCH /v1/customers/{customerId}.
+     *
+     * @property customerId The unique identifier of the customer to update.
+     */
     data class UpdateCustomer(val customerId: String): CustomerEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated list of customers via GET /v1/customers.
+     *
+     * @property perPage The number of results to return per page. Uses the API default when null.
+     * @property page The page number to retrieve. Uses the API default when null.
+     */
     data class GetCustomers(val perPage: Int? = null, val page: Int? = null): CustomerEndpoints()
+
+    /**
+     * Endpoint for fetching a single customer by ID via GET /v1/customers/{customerId}.
+     *
+     * @property customerId The unique identifier of the customer to retrieve.
+     */
     data class GetCustomerWith(val customerId: String): CustomerEndpoints()
+
+    /**
+     * Endpoint for searching customers via GET /v1/customers/search.
+     *
+     * @property q A general-purpose search query string. Pass null to omit.
+     * @property email Filters results to customers matching this email address. Pass null to omit.
+     * @property createdAfter Unix timestamp; returns only customers created after this time. Pass null to omit.
+     * @property page The page number to retrieve. Uses the API default when null.
+     * @property perPage The number of results to return per page. Uses the API default when null.
+     */
     data class SearchCustomers(val q: String? = null, val email: String? = null, val createdAfter: Int? = null, val page: Int? = null, val perPage: Int? = null): CustomerEndpoints()
+
+    /**
+     * Endpoint for deleting a customer via DELETE /v1/customers/{customerId}.
+     *
+     * @property customerId The unique identifier of the customer to delete.
+     */
     data class DeleteCustomer(val customerId: String): CustomerEndpoints()
+
+    /**
+     * Endpoint for blocking a customer via POST /v1/customers/{customerId}/block.
+     *
+     * @property customerId The unique identifier of the customer to block.
+     */
     data class BlockCustomerWith(val customerId: String): CustomerEndpoints()
+
+    /**
+     * Endpoint for unblocking a customer via POST /v1/customers/{customerId}/unblock.
+     *
+     * @property customerId The unique identifier of the customer to unblock.
+     */
     data class UnblockCustomerWith(val customerId: String): CustomerEndpoints()
 
+    /** Returns the relative URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is CreateCustomer, is GetCustomers ->
@@ -31,6 +87,7 @@ sealed class CustomerEndpoints : FrameNetworkingEndpoints {
                 "/v1/customers/${this.customerId}/unblock"
         }
 
+    /** Returns the HTTP method string for this endpoint. */
     override val httpMethod: String
         get() = when (this) {
             is CreateCustomer, is BlockCustomerWith, is UnblockCustomerWith -> "POST"
@@ -39,6 +96,7 @@ sealed class CustomerEndpoints : FrameNetworkingEndpoints {
             else -> "GET"
         }
 
+    /** Returns the URL query parameters for this endpoint, or null if none apply. */
     override val queryItems: List<QueryItem>?
         get() = when (this) {
             is GetCustomers -> {

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomersAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomersAPI.kt
@@ -5,8 +5,21 @@ import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.FrameObjects
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides coroutine-based and callback-based methods for managing customers via the Frame API.
+ *
+ * Each operation is available in two overloads: a suspend function for use with Kotlin coroutines,
+ * and a callback variant for use without coroutines.
+ */
 object CustomersAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new customer record.
+     *
+     * @param request The customer details to submit.
+     * @return A pair containing the created [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createCustomer(request: CustomersRequests.CreateCustomerRequest): Pair<FrameObjects.Customer?, NetworkingError?> {
         val endpoint = CustomerEndpoints.CreateCustomer
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -15,18 +28,38 @@ object CustomersAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Updates an existing customer record.
+     *
+     * @param customerId The unique identifier of the customer to update.
+     * @param request The updated customer details to apply.
+     * @return A pair containing the updated [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateCustomer(customerId: String, request: CustomersRequests.UpdateCustomerRequest): Pair<FrameObjects.Customer?, NetworkingError?> {
         val endpoint = CustomerEndpoints.UpdateCustomer(customerId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.Customer>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of customers.
+     *
+     * @param page The page number to retrieve. Defaults to the API's first page when null.
+     * @param perPage The number of customers per page. Defaults to the API's default page size when null.
+     * @return A pair containing a [CustomersResponses.ListCustomersResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getCustomers(page: Int? = null, perPage: Int? = null): Pair<CustomersResponses.ListCustomersResponse?, NetworkingError?> {
         val endpoint = CustomerEndpoints.GetCustomers(perPage = perPage, page = page)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<CustomersResponses.ListCustomersResponse>(data) }, error)
     }
 
+    /**
+     * Retrieves a single customer by their unique identifier.
+     *
+     * @param customerId The unique identifier of the customer to fetch.
+     * @return A pair containing the matching [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getCustomerWith(customerId: String): Pair<FrameObjects.Customer?, NetworkingError?> {
         val endpoint = CustomerEndpoints.GetCustomerWith(customerId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -35,24 +68,48 @@ object CustomersAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Searches customers using the criteria specified in the request.
+     *
+     * @param request The search parameters including optional query string, email, and date filters.
+     * @return A pair containing the matching list of [FrameObjects.Customer] objects on success, or a [NetworkingError] on failure.
+     */
     suspend fun searchCustomers(request: CustomersRequests.SearchCustomersRequest): Pair<List<FrameObjects.Customer>?, NetworkingError?> {
         val endpoint = CustomerEndpoints.SearchCustomers(request.q, request.email, request.createdAfter, request.page, request.perPage)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<CustomersResponses.ListCustomersResponse>(data)?.data }, error)
     }
 
+    /**
+     * Deletes a customer record by their unique identifier.
+     *
+     * @param customerId The unique identifier of the customer to delete.
+     * @return A pair containing the deleted [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     suspend fun deleteCustomer(customerId: String): Pair<FrameObjects.Customer?, NetworkingError?> {
         val endpoint = CustomerEndpoints.DeleteCustomer(customerId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.Customer>(data) }, error)
     }
 
+    /**
+     * Blocks a customer, preventing them from completing transactions.
+     *
+     * @param customerId The unique identifier of the customer to block.
+     * @return A pair containing the updated [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     suspend fun blockCustomerWith(customerId: String): Pair<FrameObjects.Customer?, NetworkingError?> {
         val endpoint = CustomerEndpoints.BlockCustomerWith(customerId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(null))
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.Customer>(data) }, error)
     }
 
+    /**
+     * Unblocks a previously blocked customer, restoring their ability to transact.
+     *
+     * @param customerId The unique identifier of the customer to unblock.
+     * @return A pair containing the updated [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     suspend fun unblockCustomerWith(customerId: String): Pair<FrameObjects.Customer?, NetworkingError?> {
         val endpoint = CustomerEndpoints.UnblockCustomerWith(customerId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(null))
@@ -60,6 +117,13 @@ object CustomersAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new customer record and delivers the result to a callback.
+     *
+     * @param request The customer details to submit.
+     * @param completionHandler Invoked with the created [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     fun createCustomer(request: CustomersRequests.CreateCustomerRequest, completionHandler: (FrameObjects.Customer?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.CreateCustomer
 
@@ -69,6 +133,13 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Updates an existing customer record and delivers the result to a callback.
+     *
+     * @param customerId The unique identifier of the customer to update.
+     * @param request The updated customer details to apply.
+     * @param completionHandler Invoked with the updated [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     fun updateCustomer(customerId: String, request: CustomersRequests.UpdateCustomerRequest, completionHandler: (FrameObjects.Customer?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.UpdateCustomer(customerId)
 
@@ -77,6 +148,13 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of customers and delivers the result to a callback.
+     *
+     * @param page The page number to retrieve. Defaults to the API's first page when null.
+     * @param perPage The number of customers per page. Defaults to the API's default page size when null.
+     * @param completionHandler Invoked with a [CustomersResponses.ListCustomersResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getCustomers(page: Int? = null, perPage: Int? = null, completionHandler: (CustomersResponses.ListCustomersResponse?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.GetCustomers(perPage = perPage, page = page)
 
@@ -85,6 +163,12 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Retrieves a single customer by their unique identifier and delivers the result to a callback.
+     *
+     * @param customerId The unique identifier of the customer to fetch.
+     * @param completionHandler Invoked with the matching [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     fun getCustomerWith(customerId: String, completionHandler: (FrameObjects.Customer?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.GetCustomerWith(customerId)
 
@@ -94,6 +178,12 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Searches customers using the criteria specified in the request and delivers results to a callback.
+     *
+     * @param request The search parameters including optional query string, email, and date filters.
+     * @param completionHandler Invoked with the matching list of [FrameObjects.Customer] objects on success, or a [NetworkingError] on failure.
+     */
     fun searchCustomers(request: CustomersRequests.SearchCustomersRequest, completionHandler: (List<FrameObjects.Customer>?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.SearchCustomers(request.q, request.email, request.createdAfter, request.page, request.perPage)
 
@@ -102,6 +192,12 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Deletes a customer record by their unique identifier and delivers the result to a callback.
+     *
+     * @param customerId The unique identifier of the customer to delete.
+     * @param completionHandler Invoked with the deleted [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     fun deleteCustomer(customerId: String, completionHandler: (FrameObjects.Customer?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.DeleteCustomer(customerId)
 
@@ -110,6 +206,12 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Blocks a customer and delivers the result to a callback.
+     *
+     * @param customerId The unique identifier of the customer to block.
+     * @param completionHandler Invoked with the updated [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     fun blockCustomerWith(customerId: String, completionHandler: (FrameObjects.Customer?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.BlockCustomerWith(customerId)
 
@@ -118,6 +220,12 @@ object CustomersAPI {
         }
     }
 
+    /**
+     * Unblocks a previously blocked customer and delivers the result to a callback.
+     *
+     * @param customerId The unique identifier of the customer to unblock.
+     * @param completionHandler Invoked with the updated [FrameObjects.Customer] on success, or a [NetworkingError] on failure.
+     */
     fun unblockCustomerWith(customerId: String, completionHandler: (FrameObjects.Customer?, NetworkingError?) -> Unit) {
         val endpoint = CustomerEndpoints.UnblockCustomerWith(customerId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomersRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomersRequests.kt
@@ -2,7 +2,22 @@ package com.framepayments.framesdk.customers
 import com.google.gson.annotations.SerializedName
 import com.framepayments.framesdk.FrameObjects
 
+/**
+ * Contains request body models for customer API operations.
+ */
 object CustomersRequests {
+
+    /**
+     * Request body for creating a new customer.
+     *
+     * @property billingAddress The customer's billing address. Pass null to omit.
+     * @property shippingAddress The customer's shipping address. Pass null to omit.
+     * @property name The customer's full name. Pass null to omit.
+     * @property phone The customer's phone number. Pass null to omit.
+     * @property email The customer's email address. Pass null to omit.
+     * @property description An optional description or note about the customer. Pass null to omit.
+     * @property metadata A map of merchant-defined key-value pairs to attach to the customer. Pass null to omit.
+     */
     data class CreateCustomerRequest(
         @SerializedName("billing_address") val billingAddress: FrameObjects.BillingAddress?,
         @SerializedName("shipping_address") val shippingAddress: FrameObjects.BillingAddress?,
@@ -13,6 +28,19 @@ object CustomersRequests {
         val metadata: Map<String, String>?
     )
 
+    /**
+     * Request body for updating an existing customer.
+     *
+     * Only fields that should be changed need to be provided; pass null for any field to leave it unchanged.
+     *
+     * @property billingAddress The updated billing address. Pass null to leave unchanged.
+     * @property shippingAddress The updated shipping address. Pass null to leave unchanged.
+     * @property name The updated full name. Pass null to leave unchanged.
+     * @property phone The updated phone number. Pass null to leave unchanged.
+     * @property email The updated email address. Pass null to leave unchanged.
+     * @property description The updated description or note. Pass null to leave unchanged.
+     * @property metadata The updated map of merchant-defined key-value pairs. Pass null to leave unchanged.
+     */
     data class UpdateCustomerRequest(
         @SerializedName("billing_address") val billingAddress: FrameObjects.BillingAddress?,
         @SerializedName("shipping_address") val shippingAddress: FrameObjects.BillingAddress?,
@@ -23,6 +51,17 @@ object CustomersRequests {
         val metadata: Map<String, String>?
     )
 
+    /**
+     * Parameters for searching customers.
+     *
+     * All fields are optional; provide only the criteria relevant to the search.
+     *
+     * @property q A general-purpose search query string. Defaults to null.
+     * @property email Filters results to customers matching this email address. Defaults to null.
+     * @property createdAfter Unix timestamp; returns only customers created after this time. Defaults to null.
+     * @property page The page number to retrieve. Defaults to null, which uses the API's first page.
+     * @property perPage The number of results per page. Defaults to null, which uses the API's default page size.
+     */
     data class SearchCustomersRequest(
         val q: String? = null,
         val email: String? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomersResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/customers/CustomersResponses.kt
@@ -2,7 +2,17 @@ package com.framepayments.framesdk.customers
 import com.framepayments.framesdk.FrameMetadata
 import com.framepayments.framesdk.FrameObjects
 
+/**
+ * Contains response models returned by customer API operations.
+ */
 object CustomersResponses {
+
+    /**
+     * Response returned by list and search customer endpoints.
+     *
+     * @property meta Pagination metadata for the result set. Null if the server omits it.
+     * @property data The list of customers included in this page of results. Null if the server omits it.
+     */
     data class ListCustomersResponse(
         val meta: FrameMetadata? = null,
         val data: List<FrameObjects.Customer>? = null

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeEndpoints.kt
@@ -3,9 +3,36 @@ package com.framepayments.framesdk.disputes
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints available for dispute operations.
+ *
+ * Each case maps to a specific Frame API route and HTTP method. Callers construct the
+ * appropriate case and pass it to the networking layer to execute the request.
+ */
 sealed class DisputeEndpoints : FrameNetworkingEndpoints {
+
+    /**
+     * Endpoint for updating an existing dispute with new evidence.
+     *
+     * @property disputeId The unique identifier of the dispute to update.
+     */
     data class UpdateDispute(val disputeId: String) : DisputeEndpoints()
+
+    /**
+     * Endpoint for retrieving a single dispute by its identifier.
+     *
+     * @property disputeId The unique identifier of the dispute to retrieve.
+     */
     data class GetDispute(val disputeId: String) : DisputeEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated list of disputes, optionally filtered by charge or charge intent.
+     *
+     * @property chargeId Optional identifier of the charge to filter results by.
+     * @property chargeIntentId Optional identifier of the charge intent to filter results by.
+     * @property perPage Number of disputes to return per page.
+     * @property page The page number to retrieve.
+     */
     data class GetDisputes(
         val chargeId: String?,
         val chargeIntentId: String?,
@@ -13,6 +40,7 @@ sealed class DisputeEndpoints : FrameNetworkingEndpoints {
         val page: Int?
     ) : DisputeEndpoints()
 
+    /** The relative URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is UpdateDispute -> "/v1/disputes/${disputeId}"
@@ -20,12 +48,14 @@ sealed class DisputeEndpoints : FrameNetworkingEndpoints {
             is GetDisputes -> "/v1/disputes"
         }
 
+    /** The HTTP method used for this endpoint. */
     override val httpMethod: String
         get() = when (this) {
             is UpdateDispute -> "PATCH"
             else -> "GET"
         }
 
+    /** The query parameters appended to the request URL, or `null` if none apply. */
     override val queryItems: List<QueryItem>?
         get() = when (this) {
             is GetDisputes -> {

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeObjects.kt
@@ -2,33 +2,95 @@ package com.framepayments.framesdk.disputes
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Identifies the reason a customer filed a dispute against a charge.
+ */
 enum class DisputeReason {
+    /** The customer claims the charge is a duplicate of another transaction. */
     @SerializedName("duplicate") DUPLICATE,
+
+    /** The customer claims the transaction was unauthorized or fraudulent. */
     @SerializedName("fraudulent") FRAUDULENT,
+
+    /** A general dispute reason that does not fit a more specific category. */
     @SerializedName("general") GENERAL,
+
+    /** The customer does not recognize the charge. */
     @SerializedName("unrecognized") UNRECOGNIZED,
+
+    /** The customer's bank is unable to process the transaction. */
     @SerializedName("bank_cannot_process") BANK_CANNOT_PROCESS,
+
+    /** The customer's check was returned unpaid. */
     @SerializedName("check_returned") CHECK_RETURNED,
+
+    /** A credit owed to the customer was not processed. */
     @SerializedName("credit_not_processed") CREDIT_NOT_PROCESSED,
+
+    /** The customer voluntarily initiated the dispute. */
     @SerializedName("customer_initiated") CUSTOMER_INITIATED,
+
+    /** The customer claims a debit was not authorized. */
     @SerializedName("debit_not_authorized") DEBIT_NOT_AUTHORIZED,
+
+    /** The account details used for the charge were incorrect. */
     @SerializedName("incorrect_account_details") INCORRECT_ACCOUNT_DETAILS,
+
+    /** The customer's account had insufficient funds to cover the charge. */
     @SerializedName("insufficient_funds") INSUFFICIENT_FUNDS,
+
+    /** The customer claims the product or service was never received. */
     @SerializedName("product_not_received") PRODUCT_NOT_RECEIVED,
+
+    /** The customer claims the product or service was unacceptable or not as described. */
     @SerializedName("product_unacceptable") PRODUCT_UNACCEPTABLE,
+
+    /** The customer claims a subscription was canceled before the charge was made. */
     @SerializedName("subscription_canceled") SUBSCRIPTION_CANCELED
 }
 
+/**
+ * Represents the current lifecycle status of a dispute.
+ */
 enum class DisputeStatus {
+    /** The dispute was resolved in the merchant's favor. */
     @SerializedName("won") WON,
+
+    /** The dispute was resolved in the customer's favor. */
     @SerializedName("lost") LOST,
+
+    /** An early-warning dispute is awaiting a response from the merchant. */
     @SerializedName("warning_needs_response") WARNING_NEEDS_RESPONSE,
+
+    /** An early-warning dispute is currently under review. */
     @SerializedName("warning_under_review") WARNING_UNDER_REVIEW,
+
+    /** An early-warning dispute has been closed. */
     @SerializedName("warning_closed") WARNING_CLOSED,
+
+    /** The dispute requires a response from the merchant. */
     @SerializedName("needs_response") NEEDS_RESPONSE,
+
+    /** The dispute is currently under review by the card network or issuing bank. */
     @SerializedName("under_review") UNDER_REVIEW
 }
 
+/**
+ * Represents a dispute raised against a charge by a customer.
+ *
+ * @property id Unique identifier for the dispute.
+ * @property amount Disputed amount in the smallest currency unit (e.g. cents).
+ * @property charge Identifier of the charge associated with this dispute.
+ * @property currency Three-letter ISO currency code for the disputed amount.
+ * @property evidence Evidence submitted in support of the merchant's position.
+ * @property chargeIntent Identifier of the charge intent associated with this dispute.
+ * @property reason The reason the customer provided for the dispute.
+ * @property status The current lifecycle status of the dispute.
+ * @property disputeObject The object type string returned by the API.
+ * @property livemode `true` if the dispute was created in live mode; `false` for test mode.
+ * @property created Unix timestamp indicating when the dispute was created.
+ * @property updated Unix timestamp indicating when the dispute was last updated.
+ */
 data class Dispute(
     val id: String?,
     val amount: Int?,
@@ -44,6 +106,24 @@ data class Dispute(
     val updated: Int?
 )
 
+/**
+ * Contains the evidence fields a merchant can submit to contest a dispute.
+ *
+ * @property evidenceAccessActivityLog Log of customer access activity relevant to the dispute.
+ * @property evidenceBillingAddress Billing address associated with the customer's payment method.
+ * @property evidenceCancellationPolicy The merchant's cancellation policy as provided to the customer.
+ * @property evidenceCancellationPolicyDisclosure Explanation of how the cancellation policy was disclosed to the customer.
+ * @property evidenceCancellationRebuttal Rebuttal to the customer's claim that the cancellation policy was not honored.
+ * @property evidenceCustomerEmailAddress Email address of the customer who made the purchase.
+ * @property evidenceCustomerName Full name of the customer who made the purchase.
+ * @property evidenceCustomerPurchaseIP IP address of the customer at the time of purchase.
+ * @property evidenceDuplicateChargeExplanation Explanation clarifying why an apparently duplicate charge is valid.
+ * @property evidenceDuplicateChargeId Identifier of the charge that the customer claims is a duplicate.
+ * @property evidenceProductDescription Description of the product or service that was provided to the customer.
+ * @property evidenceRefundPolicyDisclosure Explanation of how the refund policy was disclosed to the customer.
+ * @property evidenceShippingTrackingNumber Tracking number for the shipment delivered to the customer.
+ * @property evidenceUncategorizedText Any additional evidence text that does not fit a specific category.
+ */
 data class DisputeEvidence(
     @SerializedName("access_activity_log") val evidenceAccessActivityLog: String? = null,
     @SerializedName("billing_address") val evidenceBillingAddress: String? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeRequests.kt
@@ -2,7 +2,23 @@ package com.framepayments.framesdk.disputes
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains request model classes used when submitting dispute-related API calls.
+ */
 object DisputeRequests {
+
+    /**
+     * Encapsulates the evidence fields a merchant can supply when updating a dispute.
+     *
+     * @property shippingCarrier Name of the carrier used to ship the product to the customer.
+     * @property shippingDate Date on which the product was shipped to the customer.
+     * @property shippingTrackingNumber Tracking number for the shipment delivered to the customer.
+     * @property customerPurchaseIpAddress IP address of the customer at the time of purchase.
+     * @property supportDescription Description of support interactions with the customer relevant to the dispute.
+     * @property refundRefusalExplanation Explanation of why a refund was not issued to the customer.
+     * @property refundPolicy The merchant's refund policy as provided to the customer.
+     * @property accessActivityLog Log of customer access activity relevant to the dispute.
+     */
     data class UpdateDisputeRequest(
         @SerializedName("shipping_carrier") val shippingCarrier: String? = null,
         @SerializedName("shipping_date") val shippingDate: String? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputeResponses.kt
@@ -1,6 +1,15 @@
 package com.framepayments.framesdk.disputes
 
+/**
+ * Contains response model classes returned by dispute-related API calls.
+ */
 object DisputeResponses {
+
+    /**
+     * Wraps the paginated list of disputes returned by the list-disputes endpoint.
+     *
+     * @property data The list of [Dispute] objects returned for the current page, or `null` if none exist.
+     */
     data class ListDisputesResponse(
         val data: List<Dispute>?
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputesAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/disputes/DisputesAPI.kt
@@ -3,7 +3,18 @@ package com.framepayments.framesdk.disputes
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based functions for managing disputes via the Frame API.
+ */
 object DisputesAPI {
+
+    /**
+     * Updates an existing dispute with the supplied evidence details.
+     *
+     * @param disputeId The unique identifier of the dispute to update.
+     * @param request The evidence and supporting details to submit for the dispute.
+     * @return A [Pair] containing the updated [Dispute] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateDispute(
         disputeId: String,
         request: DisputeRequests.UpdateDisputeRequest
@@ -13,12 +24,27 @@ object DisputesAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<Dispute>(data) }, error)
     }
 
+    /**
+     * Retrieves a single dispute by its identifier.
+     *
+     * @param disputeId The unique identifier of the dispute to retrieve.
+     * @return A [Pair] containing the [Dispute] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getDispute(disputeId: String): Pair<Dispute?, NetworkingError?> {
         val endpoint = DisputeEndpoints.GetDispute(disputeId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<Dispute>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of disputes, optionally filtered by charge or charge intent.
+     *
+     * @param chargeId Optional identifier of the charge to filter disputes by.
+     * @param chargeIntentId Optional identifier of the charge intent to filter disputes by.
+     * @param perPage Number of disputes to return per page. Defaults to 10.
+     * @param page The page number to retrieve. Defaults to 1.
+     * @return A [Pair] containing the [DisputeResponses.ListDisputesResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getDisputes(
         chargeId: String? = null,
         chargeIntentId: String? = null,
@@ -38,6 +64,13 @@ object DisputesAPI {
         )
     }
 
+    /**
+     * Updates an existing dispute with the supplied evidence details and delivers the result via a callback.
+     *
+     * @param disputeId The unique identifier of the dispute to update.
+     * @param request The evidence and supporting details to submit for the dispute.
+     * @param completionHandler Callback invoked with the updated [Dispute] on success, or a [NetworkingError] on failure.
+     */
     fun updateDispute(
         disputeId: String,
         request: DisputeRequests.UpdateDisputeRequest,
@@ -49,6 +82,12 @@ object DisputesAPI {
         }
     }
 
+    /**
+     * Retrieves a single dispute by its identifier and delivers the result via a callback.
+     *
+     * @param disputeId The unique identifier of the dispute to retrieve.
+     * @param completionHandler Callback invoked with the [Dispute] on success, or a [NetworkingError] on failure.
+     */
     fun getDispute(disputeId: String, completionHandler: (Dispute?, NetworkingError?) -> Unit) {
         val endpoint = DisputeEndpoints.GetDispute(disputeId)
         FrameNetworking.performDataTask(endpoint) { data, error ->
@@ -56,6 +95,15 @@ object DisputesAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of disputes and delivers the result via a callback, optionally filtered by charge or charge intent.
+     *
+     * @param chargeId Optional identifier of the charge to filter disputes by.
+     * @param chargeIntentId Optional identifier of the charge intent to filter disputes by.
+     * @param perPage Number of disputes to return per page. Defaults to 10.
+     * @param page The page number to retrieve. Defaults to 1.
+     * @param completionHandler Callback invoked with the [DisputeResponses.ListDisputesResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getDisputes(
         chargeId: String? = null,
         chargeIntentId: String? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemEndpoints.kt
@@ -3,11 +3,50 @@ package com.framepayments.framesdk.invoicelineitems
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the network endpoints used by [InvoiceLineItemsAPI] to manage invoice line items.
+ *
+ * Each subclass represents a distinct API operation and supplies the correct [endpointURL]
+ * and [httpMethod] for that operation.
+ */
 sealed class InvoiceLineItemEndpoints : FrameNetworkingEndpoints {
+
+    /**
+     * Endpoint for retrieving all line items belonging to an invoice.
+     *
+     * @property invoiceId The unique identifier of the invoice whose line items to list.
+     */
     data class ListInvoiceLineItems(val invoiceId: String) : InvoiceLineItemEndpoints()
+
+    /**
+     * Endpoint for creating a new line item on an invoice.
+     *
+     * @property invoiceId The unique identifier of the invoice to add the line item to.
+     */
     data class CreateInvoiceLineItem(val invoiceId: String) : InvoiceLineItemEndpoints()
+
+    /**
+     * Endpoint for updating an existing line item on an invoice.
+     *
+     * @property invoiceId The unique identifier of the invoice that owns the line item.
+     * @property invoiceLineItemId The unique identifier of the line item to update.
+     */
     data class UpdateInvoiceLineItem(val invoiceId: String, val invoiceLineItemId: String) : InvoiceLineItemEndpoints()
+
+    /**
+     * Endpoint for deleting a line item from an invoice.
+     *
+     * @property invoiceId The unique identifier of the invoice that owns the line item.
+     * @property invoiceLineItemId The unique identifier of the line item to delete.
+     */
     data class DeleteInvoiceLineItem(val invoiceId: String, val invoiceLineItemId: String) : InvoiceLineItemEndpoints()
+
+    /**
+     * Endpoint for retrieving a single line item by its identifier from an invoice.
+     *
+     * @property invoiceId The unique identifier of the invoice that owns the line item.
+     * @property invoiceLineItemId The unique identifier of the line item to retrieve.
+     */
     data class GetInvoiceLineItemWith(val invoiceId: String, val invoiceLineItemId: String) : InvoiceLineItemEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemObjects.kt
@@ -1,6 +1,18 @@
 package com.framepayments.framesdk.invoicelineitems
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents a single line item attached to an invoice.
+ *
+ * @property id The unique identifier of this line item.
+ * @property description A human-readable description of the line item.
+ * @property quantity The number of units included in this line item.
+ * @property created A Unix timestamp (seconds) indicating when the line item was created.
+ * @property updated A Unix timestamp (seconds) indicating when the line item was last updated.
+ * @property lineItemObject The object type string returned by the API (e.g. `"line_item"`).
+ * @property unitAmountCents The price per unit expressed in the smallest currency unit (e.g. cents).
+ * @property unitAmountCurrency The numeric currency code for [unitAmountCents].
+ */
 data class InvoiceLineItem(
     val id: String?,
     val description: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemRequests.kt
@@ -1,11 +1,29 @@
 package com.framepayments.framesdk.invoicelineitems
 
+/**
+ * Namespace for request models used by [InvoiceLineItemsAPI].
+ */
 object InvoiceLineItemRequests {
+
+    /**
+     * Request body for creating a new invoice line item.
+     *
+     * @property product The identifier of the product to associate with this line item.
+     * @property quantity The number of units to include. Must be greater than 0.
+     */
     data class CreateLineItemRequest(
         val product: String,
         val quantity: Int // Note: Must be greater than 0
     )
 
+    /**
+     * Request body for updating an existing invoice line item.
+     *
+     * Only non-null fields are applied to the existing line item.
+     *
+     * @property product The updated product identifier, or null to leave unchanged.
+     * @property quantity The updated unit quantity. Must be greater than 0 when provided.
+     */
     data class UpdateLineItemRequest(
         val product: String?,
         val quantity: Int? // Note: Must be greater than 0

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemResponses.kt
@@ -2,11 +2,26 @@ package com.framepayments.framesdk.invoicelineitems
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Namespace for response models returned by [InvoiceLineItemsAPI].
+ */
 object InvoiceLineItemResponses {
+
+    /**
+     * Response containing a list of invoice line items.
+     *
+     * @property data The collection of [InvoiceLineItem] objects returned by the API, or null if absent.
+     */
     data class ListInvoiceLineItemsResponse (
         val data: List<InvoiceLineItem>?
     )
 
+    /**
+     * Response confirming the deletion of an invoice line item.
+     *
+     * @property deletedObject The object type string identifying what was deleted (e.g. `"line_item"`).
+     * @property deleted True if the line item was successfully deleted.
+     */
     data class DeletedInvoiceLineItemResponse (
         @SerializedName("object") val deletedObject: String?,
         val deleted: Boolean?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoicelineitems/InvoiceLineItemsAPI.kt
@@ -5,8 +5,23 @@ import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.FrameObjects
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides coroutine-based and callback-based methods for managing invoice line items.
+ *
+ * Each operation returns or delivers a pair of a nullable result and a nullable [NetworkingError].
+ * Exactly one of the two will be non-null on completion.
+ */
 object InvoiceLineItemsAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new line item on the specified invoice.
+     *
+     * @param invoiceId The unique identifier of the invoice to add the line item to.
+     * @param request The details of the line item to create.
+     * @return A [Pair] where the first element is the created [InvoiceLineItem] on success,
+     * and the second element is a [NetworkingError] on failure.
+     */
     suspend fun createInvoiceLineItem(invoiceId: String, request: InvoiceLineItemRequests.CreateLineItemRequest): Pair<InvoiceLineItem?, NetworkingError?> {
         val endpoint = InvoiceLineItemEndpoints.CreateInvoiceLineItem(invoiceId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -15,18 +30,42 @@ object InvoiceLineItemsAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Updates an existing line item on the specified invoice.
+     *
+     * @param invoiceId The unique identifier of the invoice that owns the line item.
+     * @param invoiceLineItemId The unique identifier of the line item to update.
+     * @param request The fields to update on the line item.
+     * @return A [Pair] where the first element is the updated [InvoiceLineItem] on success,
+     * and the second element is a [NetworkingError] on failure.
+     */
     suspend fun updateInvoiceLineItem(invoiceId: String, invoiceLineItemId: String, request: InvoiceLineItemRequests.UpdateLineItemRequest): Pair<InvoiceLineItem?, NetworkingError?> {
         val endpoint = InvoiceLineItemEndpoints.UpdateInvoiceLineItem(invoiceId, invoiceLineItemId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<InvoiceLineItem>(data) }, error)
     }
 
+    /**
+     * Retrieves all line items belonging to the specified invoice.
+     *
+     * @param invoiceId The unique identifier of the invoice whose line items to fetch.
+     * @return A [Pair] where the first element is a [InvoiceLineItemResponses.ListInvoiceLineItemsResponse]
+     * containing the list on success, and the second element is a [NetworkingError] on failure.
+     */
     suspend fun getInvoiceLineItems(invoiceId: String): Pair<InvoiceLineItemResponses.ListInvoiceLineItemsResponse?, NetworkingError?> {
         val endpoint = InvoiceLineItemEndpoints.ListInvoiceLineItems(invoiceId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<InvoiceLineItemResponses.ListInvoiceLineItemsResponse>(data) }, error)
     }
 
+    /**
+     * Retrieves a single line item by its identifier from the specified invoice.
+     *
+     * @param invoiceId The unique identifier of the invoice that owns the line item.
+     * @param invoiceLineItemId The unique identifier of the line item to retrieve.
+     * @return A [Pair] where the first element is the matching [InvoiceLineItem] on success,
+     * and the second element is a [NetworkingError] on failure.
+     */
     suspend fun getInvoiceLineItemWith(invoiceId: String, invoiceLineItemId: String): Pair<InvoiceLineItem?, NetworkingError?> {
         val endpoint = InvoiceLineItemEndpoints.GetInvoiceLineItemWith(invoiceId, invoiceLineItemId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -35,6 +74,14 @@ object InvoiceLineItemsAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Deletes a line item from the specified invoice.
+     *
+     * @param invoiceId The unique identifier of the invoice that owns the line item.
+     * @param invoiceLineItemId The unique identifier of the line item to delete.
+     * @return A [Pair] where the first element is a [InvoiceLineItemResponses.DeletedInvoiceLineItemResponse]
+     * confirming deletion on success, and the second element is a [NetworkingError] on failure.
+     */
     suspend fun deleteInvoiceLineItem(invoiceId: String, invoiceLineItemId: String): Pair<InvoiceLineItemResponses.DeletedInvoiceLineItemResponse?, NetworkingError?> {
         val endpoint = InvoiceLineItemEndpoints.DeleteInvoiceLineItem(invoiceId, invoiceLineItemId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -42,6 +89,15 @@ object InvoiceLineItemsAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new line item on the specified invoice, delivering the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice to add the line item to.
+     * @param request The details of the line item to create.
+     * @param completionHandler Called on completion with the created [InvoiceLineItem] on success,
+     * or a [NetworkingError] on failure.
+     */
     fun createInvoiceLineItem(invoiceId: String, request: InvoiceLineItemRequests.CreateLineItemRequest, completionHandler: (InvoiceLineItem?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceLineItemEndpoints.CreateInvoiceLineItem(invoiceId)
 
@@ -51,6 +107,15 @@ object InvoiceLineItemsAPI {
         }
     }
 
+    /**
+     * Updates an existing line item on the specified invoice, delivering the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice that owns the line item.
+     * @param invoiceLineItemId The unique identifier of the line item to update.
+     * @param request The fields to update on the line item.
+     * @param completionHandler Called on completion with the updated [InvoiceLineItem] on success,
+     * or a [NetworkingError] on failure.
+     */
     fun updateInvoiceLineItem(invoiceId: String, invoiceLineItemId: String, request: InvoiceLineItemRequests.UpdateLineItemRequest, completionHandler: (InvoiceLineItem?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceLineItemEndpoints.UpdateInvoiceLineItem(invoiceId, invoiceLineItemId)
 
@@ -59,6 +124,13 @@ object InvoiceLineItemsAPI {
         }
     }
 
+    /**
+     * Retrieves all line items belonging to the specified invoice, delivering the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice whose line items to fetch.
+     * @param completionHandler Called on completion with a [InvoiceLineItemResponses.ListInvoiceLineItemsResponse]
+     * on success, or a [NetworkingError] on failure.
+     */
     fun getInvoiceLineItems(invoiceId: String, completionHandler: (InvoiceLineItemResponses.ListInvoiceLineItemsResponse?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceLineItemEndpoints.ListInvoiceLineItems(invoiceId)
 
@@ -67,6 +139,14 @@ object InvoiceLineItemsAPI {
         }
     }
 
+    /**
+     * Retrieves a single line item by its identifier from the specified invoice, delivering the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice that owns the line item.
+     * @param invoiceLineItemId The unique identifier of the line item to retrieve.
+     * @param completionHandler Called on completion with the matching [InvoiceLineItem] on success,
+     * or a [NetworkingError] on failure.
+     */
     fun getInvoiceLineItemWith(invoiceId: String, invoiceLineItemId: String, completionHandler: (InvoiceLineItem?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceLineItemEndpoints.GetInvoiceLineItemWith(invoiceId, invoiceLineItemId)
 
@@ -76,6 +156,14 @@ object InvoiceLineItemsAPI {
         }
     }
 
+    /**
+     * Deletes a line item from the specified invoice, delivering the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice that owns the line item.
+     * @param invoiceLineItemId The unique identifier of the line item to delete.
+     * @param completionHandler Called on completion with a [InvoiceLineItemResponses.DeletedInvoiceLineItemResponse]
+     * confirming deletion on success, or a [NetworkingError] on failure.
+     */
     fun deleteInvoiceLineItem(invoiceId: String, invoiceLineItemId: String, completionHandler: (InvoiceLineItemResponses.DeletedInvoiceLineItemResponse?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceLineItemEndpoints.DeleteInvoiceLineItem(invoiceId, invoiceLineItemId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceEndpoints.kt
@@ -3,14 +3,57 @@ package com.framepayments.framesdk.invoices
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints available for invoice operations.
+ *
+ * Each case maps to a specific URL path, HTTP method, and optional query parameters
+ * used by the networking layer to construct requests.
+ */
 sealed class InvoiceEndpoints : FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new invoice (`POST /v1/invoices`). */
     object CreateInvoice: InvoiceEndpoints()
+
+    /**
+     * Endpoint for updating an existing invoice (`PATCH /v1/invoices/{invoiceId}`).
+     *
+     * @property invoiceId The unique identifier of the invoice to update.
+     */
     data class UpdateInvoice(val invoiceId: String): InvoiceEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated, optionally filtered list of invoices (`GET /v1/invoices`).
+     *
+     * @property perPage The number of results to return per page.
+     * @property page The page number to retrieve.
+     * @property customer The customer ID to filter results by.
+     * @property account The account ID to filter results by.
+     * @property status The [InvoiceStatus] to filter results by.
+     */
     data class GetInvoices(val perPage: Int? = null, val page: Int? = null, val customer: String? = null, val account: String? = null, val status: InvoiceStatus? = null): InvoiceEndpoints()
+
+    /**
+     * Endpoint for retrieving a single invoice by identifier (`GET /v1/invoices/{invoiceId}`).
+     *
+     * @property invoiceId The unique identifier of the invoice to retrieve.
+     */
     data class GetInvoiceWith(val invoiceId: String): InvoiceEndpoints()
+
+    /**
+     * Endpoint for deleting an invoice (`DELETE /v1/invoices/{invoiceId}`).
+     *
+     * @property invoiceId The unique identifier of the invoice to delete.
+     */
     data class DeleteInvoice(val invoiceId: String): InvoiceEndpoints()
+
+    /**
+     * Endpoint for issuing a draft invoice to the customer (`POST /v1/invoices/{invoiceId}/issue`).
+     *
+     * @property invoiceId The unique identifier of the invoice to issue.
+     */
     data class IssueInvoice(val invoiceId: String): InvoiceEndpoints()
 
+    /** The URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is CreateInvoice, is GetInvoices ->
@@ -25,6 +68,7 @@ sealed class InvoiceEndpoints : FrameNetworkingEndpoints {
                 "/v1/invoices/${this.invoiceId}/issue"
         }
 
+    /** The HTTP method for this endpoint. */
     override val httpMethod: String
         get() = when (this) {
             is CreateInvoice, is IssueInvoice -> "POST"
@@ -33,6 +77,7 @@ sealed class InvoiceEndpoints : FrameNetworkingEndpoints {
             else -> "GET"
         }
 
+    /** The query parameters to append to the request URL, or null if none apply. */
     override val queryItems: List<QueryItem>?
         get() = when (this) {
             is GetInvoices -> {

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceObjects.kt
@@ -3,22 +3,52 @@ package com.framepayments.framesdk.invoices
 import com.framepayments.framesdk.FrameObjects
 import com.google.gson.annotations.SerializedName
 
+/** Specifies how payment is collected for an invoice. */
 enum class InvoiceCollectionMethod {
+    /** Automatically charges the customer's payment method on the due date. */
     @SerializedName("auto_charge") AUTO_CHARGE,
+    /** Sends the customer a payment request and waits for them to pay manually. */
     @SerializedName("request_payment") REQUEST_PAYMENT
 }
 
+/** Represents the lifecycle state of an invoice. */
 enum class InvoiceStatus {
-
+    /** The invoice has been created but not yet issued to the customer. */
     @SerializedName("draft") DRAFT,
+    /** The invoice has been issued and payment is expected but not yet due. */
     @SerializedName("outstanding") OUTSTANDING,
+    /** The invoice payment is due today. */
     @SerializedName("due") DUE,
+    /** The invoice payment is past its due date. */
     @SerializedName("overdue") OVERDUE,
+    /** The invoice has been fully paid. */
     @SerializedName("paid") PAID,
+    /** The invoice has been written off as uncollectable. */
     @SerializedName("written_off") WRITTEN_OFF,
+    /** The invoice has been voided and is no longer payable. */
     @SerializedName("voided") VOIDED;
 }
 
+/**
+ * Represents an invoice issued to a customer.
+ *
+ * @property id Unique identifier for the invoice.
+ * @property customer The customer this invoice was issued to.
+ * @property total The total amount due, in the smallest currency unit (e.g., cents).
+ * @property currency The ISO 4217 currency code for the invoice amount.
+ * @property status The current lifecycle status of the invoice.
+ * @property memo An internal memo visible only to the merchant.
+ * @property livemode Whether the invoice was created in live mode (`true`) or test mode (`false`).
+ * @property metadata Arbitrary key-value pairs the merchant can attach for their own reference.
+ * @property created Unix timestamp of when the invoice was created.
+ * @property updated Unix timestamp of when the invoice was last updated.
+ * @property invoiceObject The object type identifier returned by the API (e.g., `"invoice"`).
+ * @property lineItems The list of line items included on the invoice.
+ * @property collectionMethod How payment is collected for this invoice.
+ * @property netTerms The number of days from issuance until the invoice is due.
+ * @property invoiceNumber The merchant-assigned number for this invoice.
+ * @property invoiceDescription A customer-facing description of the invoice.
+ */
 data class Invoice(
     val id: String?,
     val customer: FrameObjects.Customer?,
@@ -38,6 +68,12 @@ data class Invoice(
     @SerializedName("description") val invoiceDescription: String?,
 )
 
+/**
+ * Represents a single line item on an invoice.
+ *
+ * @property product The identifier of the product associated with this line item.
+ * @property quantity The number of units of the product included.
+ */
 data class LineItem(
     val product: String?,
     val quantity: Int?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceRequests.kt
@@ -2,7 +2,23 @@ package com.framepayments.framesdk.invoices
 
 import com.google.gson.annotations.SerializedName
 
+/** Holds request body models for invoice API operations. */
 object InvoiceRequests {
+
+    /**
+     * Request body for creating a new invoice.
+     *
+     * @property collectionMethod How payment will be collected for this invoice. Required.
+     * @property netTerms The number of days from issuance until the invoice is due.
+     * @property lineItems The products and quantities to include on the invoice.
+     * @property customer The ID of the customer to invoice. Pass null to associate later.
+     * @property account The ID of the connected account to create the invoice on behalf of.
+     * @property dueDate An explicit due date for the invoice (ISO 8601 date string). Overrides [netTerms] when provided.
+     * @property number A merchant-assigned number for the invoice.
+     * @property description A customer-facing description of the invoice.
+     * @property memo An internal memo visible only to the merchant.
+     * @property metadata Arbitrary key-value pairs the merchant can attach for their own reference.
+     */
     data class CreateInvoiceRequest (
         @SerializedName("collection_method") val collectionMethod: InvoiceCollectionMethod,
         @SerializedName("net_terms") val netTerms: Int?,
@@ -16,6 +32,21 @@ object InvoiceRequests {
         val metadata: Map<String,String>?
     )
 
+    /**
+     * Request body for updating an existing invoice.
+     *
+     * All fields are optional; only non-null values are applied to the invoice.
+     *
+     * @property collectionMethod Replaces how payment is collected for this invoice.
+     * @property netTerms Replaces the number of days from issuance until the invoice is due.
+     * @property lineItems Replaces the full list of line items on the invoice.
+     * @property dueDate Replaces the explicit due date (ISO 8601 date string).
+     * @property autoAdvance When `true`, automatically advances the invoice to the next status when its conditions are met.
+     * @property number Replaces the merchant-assigned number for the invoice.
+     * @property description Replaces the customer-facing description of the invoice.
+     * @property memo Replaces the internal memo visible only to the merchant.
+     * @property metadata Replaces the arbitrary key-value pairs attached to the invoice.
+     */
     data class UpdateInvoiceRequest(
         @SerializedName("collection_method") val collectionMethod: InvoiceCollectionMethod? = null,
         @SerializedName("net_terms") val netTerms: Int? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoiceResponses.kt
@@ -3,12 +3,26 @@ package com.framepayments.framesdk.invoices
 import com.framepayments.framesdk.FrameMetadata
 import com.google.gson.annotations.SerializedName
 
+/** Holds response body models for invoice API operations. */
 object InvoiceResponses {
+
+    /**
+     * Response returned by the list-invoices endpoint.
+     *
+     * @property meta Pagination metadata for the result set.
+     * @property data The invoices returned for the current page.
+     */
     data class ListInvoicesResponse (
         val meta: FrameMetadata?,
         val data: List<Invoice>?
     )
 
+    /**
+     * Response returned after successfully deleting an invoice.
+     *
+     * @property deletedObject The object type identifier of the deleted resource (e.g., `"invoice"`).
+     * @property deleted Whether the deletion was successful.
+     */
     data class DeletedInvoiceResponse (
         @SerializedName("object") val deletedObject: String?,
         val deleted: Boolean?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoicesAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/invoices/InvoicesAPI.kt
@@ -4,8 +4,16 @@ import com.framepayments.framesdk.EmptyRequest
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/** Provides coroutine and callback entry points for all invoice-related API operations. */
 object InvoicesAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new invoice.
+     *
+     * @param request The parameters for the invoice to create.
+     * @return A pair containing the created [Invoice] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createInvoice(request: InvoiceRequests.CreateInvoiceRequest): Pair<Invoice?, NetworkingError?> {
         val endpoint = InvoiceEndpoints.CreateInvoice
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -14,18 +22,41 @@ object InvoicesAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Updates an existing invoice.
+     *
+     * @param invoiceId The unique identifier of the invoice to update.
+     * @param request The fields to update on the invoice.
+     * @return A pair containing the updated [Invoice] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateInvoice(invoiceId: String, request: InvoiceRequests.UpdateInvoiceRequest): Pair<Invoice?, NetworkingError?> {
         val endpoint = InvoiceEndpoints.UpdateInvoice(invoiceId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Invoice>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of invoices, optionally filtered by customer, account, or status.
+     *
+     * @param page The page number to retrieve. Defaults to the first page when null.
+     * @param perPage The number of invoices per page. Uses the API default when null.
+     * @param customer The customer ID to filter results by. Returns invoices for all customers when null.
+     * @param account The account ID to filter results by. Returns invoices for all accounts when null.
+     * @param status The [InvoiceStatus] to filter results by. Returns invoices of all statuses when null.
+     * @return A pair containing a [InvoiceResponses.ListInvoicesResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getInvoices(page: Int? = null, perPage: Int? = null, customer: String? = null, account: String? = null, status: InvoiceStatus? = null): Pair<InvoiceResponses.ListInvoicesResponse?, NetworkingError?> {
         val endpoint = InvoiceEndpoints.GetInvoices(perPage = perPage, page = page, customer = customer, account = account, status = status)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<InvoiceResponses.ListInvoicesResponse>(data) }, error)
     }
 
+    /**
+     * Retrieves a single invoice by its identifier.
+     *
+     * @param invoiceId The unique identifier of the invoice to retrieve.
+     * @return A pair containing the matching [Invoice] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getInvoiceWith(invoiceId: String): Pair<Invoice?, NetworkingError?> {
         val endpoint = InvoiceEndpoints.GetInvoiceWith(invoiceId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -34,12 +65,24 @@ object InvoicesAPI {
         return Pair(decodedResponse, error)
     }
 
+    /**
+     * Deletes an invoice by its identifier.
+     *
+     * @param invoiceId The unique identifier of the invoice to delete.
+     * @return A pair containing a [InvoiceResponses.DeletedInvoiceResponse] confirming deletion on success, or a [NetworkingError] on failure.
+     */
     suspend fun deleteInvoice(invoiceId: String): Pair<InvoiceResponses.DeletedInvoiceResponse?, NetworkingError?> {
         val endpoint = InvoiceEndpoints.DeleteInvoice(invoiceId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<InvoiceResponses.DeletedInvoiceResponse>(data) }, error)
     }
 
+    /**
+     * Issues a draft invoice, making it visible to the customer.
+     *
+     * @param invoiceId The unique identifier of the invoice to issue.
+     * @return A pair containing the issued [Invoice] on success, or a [NetworkingError] on failure.
+     */
     suspend fun issueInvoice(invoiceId: String): Pair<Invoice?, NetworkingError?> {
         val endpoint = InvoiceEndpoints.IssueInvoice(invoiceId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(null))
@@ -49,6 +92,13 @@ object InvoicesAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new invoice and delivers the result via a callback.
+     *
+     * @param request The parameters for the invoice to create.
+     * @param completionHandler Invoked on completion with the created [Invoice] on success, or a [NetworkingError] on failure.
+     */
     fun createInvoice(request: InvoiceRequests.CreateInvoiceRequest, completionHandler: (Invoice?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceEndpoints.CreateInvoice
 
@@ -58,6 +108,13 @@ object InvoicesAPI {
         }
     }
 
+    /**
+     * Updates an existing invoice and delivers the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice to update.
+     * @param request The fields to update on the invoice.
+     * @param completionHandler Invoked on completion with the updated [Invoice] on success, or a [NetworkingError] on failure.
+     */
     fun updateInvoice(invoiceId: String, request: InvoiceRequests.UpdateInvoiceRequest, completionHandler: (Invoice?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceEndpoints.UpdateInvoice(invoiceId)
 
@@ -66,6 +123,16 @@ object InvoicesAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of invoices and delivers the result via a callback.
+     *
+     * @param page The page number to retrieve. Defaults to the first page when null.
+     * @param perPage The number of invoices per page. Uses the API default when null.
+     * @param customer The customer ID to filter results by. Returns invoices for all customers when null.
+     * @param account The account ID to filter results by. Returns invoices for all accounts when null.
+     * @param status The [InvoiceStatus] to filter results by. Returns invoices of all statuses when null.
+     * @param completionHandler Invoked on completion with a [InvoiceResponses.ListInvoicesResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getInvoices(page: Int? = null, perPage: Int? = null, customer: String? = null, account: String? = null, status: InvoiceStatus? = null, completionHandler: (InvoiceResponses.ListInvoicesResponse?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceEndpoints.GetInvoices(perPage = perPage, page = page, customer = customer, account = account, status = status)
 
@@ -74,6 +141,12 @@ object InvoicesAPI {
         }
     }
 
+    /**
+     * Retrieves a single invoice by its identifier and delivers the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice to retrieve.
+     * @param completionHandler Invoked on completion with the matching [Invoice] on success, or a [NetworkingError] on failure.
+     */
     fun getInvoiceWith(invoiceId: String, completionHandler: (Invoice?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceEndpoints.GetInvoiceWith(invoiceId)
 
@@ -82,6 +155,12 @@ object InvoicesAPI {
         }
     }
 
+    /**
+     * Deletes an invoice by its identifier and delivers the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice to delete.
+     * @param completionHandler Invoked on completion with a [InvoiceResponses.DeletedInvoiceResponse] confirming deletion on success, or a [NetworkingError] on failure.
+     */
     fun deleteInvoice(invoiceId: String, completionHandler: (InvoiceResponses.DeletedInvoiceResponse?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceEndpoints.DeleteInvoice(invoiceId)
 
@@ -90,6 +169,12 @@ object InvoicesAPI {
         }
     }
 
+    /**
+     * Issues a draft invoice and delivers the result via a callback.
+     *
+     * @param invoiceId The unique identifier of the invoice to issue.
+     * @param completionHandler Invoked on completion with the issued [Invoice] on success, or a [NetworkingError] on failure.
+     */
     fun issueInvoice(invoiceId: String, completionHandler: (Invoice?, NetworkingError?) -> Unit) {
         val endpoint = InvoiceEndpoints.IssueInvoice(invoiceId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodEndpoints.kt
@@ -3,17 +3,87 @@ package com.framepayments.framesdk.paymentmethods
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines every HTTP endpoint used by [PaymentMethodsAPI].
+ *
+ * Each case encapsulates the path parameters required to construct the endpoint URL, the HTTP
+ * method, and any query string items. Merchants interact with these indirectly through
+ * [PaymentMethodsAPI] and do not need to instantiate cases directly.
+ */
 sealed class PaymentMethodEndpoints : FrameNetworkingEndpoints {
+
+    /**
+     * Fetches a paginated list of all payment methods.
+     *
+     * @property perPage Number of results to return per page.
+     * @property page 1-based page number to retrieve.
+     */
     data class GetPaymentMethods(val perPage: Int? = null, val page: Int? = null) : PaymentMethodEndpoints()
+
+    /**
+     * Fetches a single payment method by its unique identifier.
+     *
+     * @property paymentMethodId The unique identifier of the payment method to retrieve.
+     */
     data class GetPaymentMethodWith(val paymentMethodId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Fetches all payment methods associated with a specific customer.
+     *
+     * @property customerId The unique identifier of the customer whose payment methods to retrieve.
+     */
     data class GetPaymentMethodsWithCustomer(val customerId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Fetches all payment methods associated with a specific merchant account.
+     *
+     * @property accountId The unique identifier of the account whose payment methods to retrieve.
+     */
     data class GetPaymentMethodsWithAccount(val accountId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Creates a new payment method (card, ACH, or Google Pay).
+     */
     object CreatePaymentMethod : PaymentMethodEndpoints()
+
+    /**
+     * Updates mutable fields on an existing payment method.
+     *
+     * @property paymentMethodId The unique identifier of the payment method to update.
+     */
     data class UpdatePaymentMethodWith(val paymentMethodId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Attaches a payment method to a customer or merchant account.
+     *
+     * @property paymentMethodId The unique identifier of the payment method to attach.
+     */
     data class AttachPaymentMethodWith(val paymentMethodId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Detaches a payment method from its associated customer or account.
+     *
+     * @property paymentMethodId The unique identifier of the payment method to detach.
+     */
     data class DetachPaymentMethodWith(val paymentMethodId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Blocks a payment method, preventing it from being used for new transactions.
+     *
+     * @property paymentMethodId The unique identifier of the payment method to block.
+     */
     data class BlockPaymentMethodWith(val paymentMethodId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Unblocks a previously blocked payment method, restoring its ability to be used for transactions.
+     *
+     * @property paymentMethodId The unique identifier of the payment method to unblock.
+     */
     data class UnblockPaymentMethodWith(val paymentMethodId: String) : PaymentMethodEndpoints()
+
+    /**
+     * Creates an ACH payment method by exchanging a Plaid public token for a connected bank account.
+     */
     object ConnectPlaidBankAccount : PaymentMethodEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodRequests.kt
@@ -2,7 +2,25 @@ package com.framepayments.framesdk.paymentmethods
 import com.google.gson.annotations.SerializedName
 import com.framepayments.framesdk.FrameObjects
 
+/**
+ * Contains all request body models used by [PaymentMethodsAPI].
+ */
 object PaymentMethodRequests {
+
+    /**
+     * Request body for creating a card payment method.
+     *
+     * @property type Payment method type; always [FrameObjects.PaymentMethodType.CARD].
+     * @property cardNumber The card number. Encrypted via Evervault before transmission when
+     *   [PaymentMethodsAPI.createCardPaymentMethod] is called with `encryptData = true`.
+     * @property expMonth Two-digit card expiration month (e.g., `"04"`).
+     * @property expYear Four-digit card expiration year (e.g., `"2027"`).
+     * @property cvc The card verification code. Encrypted via Evervault before transmission when
+     *   [PaymentMethodsAPI.createCardPaymentMethod] is called with `encryptData = true`.
+     * @property customer Optional identifier of the customer to associate with this payment method.
+     * @property account Optional identifier of the merchant account to associate with this payment method.
+     * @property billing Optional billing address to attach to this payment method.
+     */
     data class CreateCardPaymentMethodRequest(
         val type: FrameObjects.PaymentMethodType = FrameObjects.PaymentMethodType.CARD,
         @SerializedName("card_number") var cardNumber: String,
@@ -14,6 +32,17 @@ object PaymentMethodRequests {
         val billing: FrameObjects.BillingAddress? = null
     )
 
+    /**
+     * Request body for creating an ACH bank-account payment method.
+     *
+     * @property type Payment method type; always [FrameObjects.PaymentMethodType.ACH].
+     * @property accountType The bank account type (e.g., checking or savings).
+     * @property accountNumber The bank account number.
+     * @property routingNumber The nine-digit ABA routing number.
+     * @property customer Optional identifier of the customer to associate with this payment method.
+     * @property account Optional identifier of the merchant account to associate with this payment method.
+     * @property billing Optional billing address to attach to this payment method.
+     */
     data class CreateACHPaymentMethodRequest(
         val type: FrameObjects.PaymentMethodType = FrameObjects.PaymentMethodType.ACH,
         @SerializedName("account_type") val accountType: FrameObjects.PaymentAccountType,
@@ -24,17 +53,42 @@ object PaymentMethodRequests {
         val billing: FrameObjects.BillingAddress? = null
     )
 
+    /**
+     * Request body for updating an existing payment method.
+     *
+     * All fields are optional; only provided fields are updated.
+     *
+     * @property expMonth Updated two-digit expiration month. Applicable to card payment methods only.
+     * @property expYear Updated four-digit expiration year. Applicable to card payment methods only.
+     * @property billing Updated billing address.
+     */
     data class UpdatePaymentMethodRequest(
         @SerializedName("exp_month") val expMonth: String? = null, // Only used for `card` type
         @SerializedName("exp_year") val expYear: String? = null, // Only used for `card` type
         val billing: FrameObjects.BillingAddress? = null
     )
 
+    /**
+     * Request body for attaching a payment method to a customer or merchant account.
+     *
+     * At least one of [customer] or [account] should be provided.
+     *
+     * @property customer Identifier of the customer to attach the payment method to.
+     * @property account Identifier of the merchant account to attach the payment method to.
+     */
     data class AttachPaymentMethodRequest(
         val customer: String? = null,
         val account: String? = null
     )
 
+    /**
+     * Decoded Google Pay payment data returned by the Google Pay API.
+     *
+     * @property apiVersion Major version number of the Google Pay API used to generate the token.
+     * @property apiVersionMinor Minor version number of the Google Pay API used to generate the token.
+     * @property email Customer email address returned by Google Pay, if present.
+     * @property paymentMethodData The raw payment method data object returned by Google Pay.
+     */
     data class GooglePayWalletData(
         val apiVersion: Int,
         val apiVersionMinor: Int,
@@ -42,18 +96,41 @@ object PaymentMethodRequests {
         val paymentMethodData: Any
     )
 
+    /**
+     * Wrapper that identifies the wallet provider and carries the decoded Google Pay token.
+     *
+     * @property type Wallet type identifier; always `"google_pay"`.
+     * @property googlePay The decoded Google Pay payment data.
+     */
     data class GooglePayWallet(
         val type: String = "google_pay",
         @SerializedName("google_pay") val googlePay: GooglePayWalletData
     )
 
+    /**
+     * Request body for creating a payment method from a Google Pay wallet token.
+     *
+     * @property type Payment method type; always `"card"`.
+     * @property wallet The Google Pay wallet wrapper containing the decoded token.
+     * @property customer Optional identifier of the customer to associate with this payment method.
+     * @property account Optional identifier of the merchant account to associate with this payment method.
+     */
     data class CreateGooglePayPaymentMethodRequest(
         val type: String = "card",
         @SerializedName("_wallet") val wallet: GooglePayWallet,
         val customer: String? = null,
         val account: String? = null
     )
-    
+
+    /**
+     * Request body for creating an ACH payment method by connecting a bank account via Plaid.
+     *
+     * @property account Identifier of the merchant account to associate with this payment method.
+     * @property publicToken Short-lived public token obtained from the Plaid Link flow.
+     * @property accountId Plaid account identifier selected by the customer during the Link flow.
+     * @property institutionName Human-readable name of the financial institution, if available.
+     * @property subtype Plaid account subtype (e.g., `"checking"` or `"savings"`), if available.
+     */
     data class ConnectPlaidBankAccountRequest(
         val account: String,
         @SerializedName("public_token") val publicToken: String,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodResponses.kt
@@ -2,7 +2,17 @@ package com.framepayments.framesdk.paymentmethods
 import com.framepayments.framesdk.FrameMetadata
 import com.framepayments.framesdk.FrameObjects
 
+/**
+ * Contains all response body models returned by [PaymentMethodsAPI].
+ */
 object PaymentMethodResponses {
+
+    /**
+     * Paginated response returned when listing payment methods.
+     *
+     * @property meta Pagination metadata (page, per-page count, total records, etc.), if present.
+     * @property data The list of payment methods on the current page, if present.
+     */
     data class ListPaymentMethodsResponse(
         val meta: FrameMetadata? = null,
         val data: List<FrameObjects.PaymentMethod>? = null

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/paymentmethods/PaymentMethodsAPI.kt
@@ -9,32 +9,76 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
+/**
+ * Provides suspend and callback overloads for all payment method API operations.
+ *
+ * Every function returns a [Pair] whose first element is the parsed response on success and
+ * whose second element is a [NetworkingError] on failure; exactly one of the two is non-null
+ * at a time.
+ */
 object PaymentMethodsAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Fetches a paginated list of payment methods.
+     *
+     * @param page 1-based page number to retrieve, or null for the server default.
+     * @param perPage Number of results per page, or null for the server default.
+     * @return A pair of the paginated response and a networking error.
+     */
     suspend fun getPaymentMethods(page: Int? = null, perPage: Int? = null): Pair<PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethods(perPage = perPage, page = page)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<PaymentMethodResponses.ListPaymentMethodsResponse>(data) }, error)
     }
 
+    /**
+     * Fetches a single payment method by its unique identifier.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to retrieve.
+     * @return A pair of the matching payment method and a networking error.
+     */
     suspend fun getPaymentMethodWith(paymentMethodId: String): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethodWith(paymentMethodId = paymentMethodId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Fetches all payment methods associated with a specific customer.
+     *
+     * @param customerId The unique identifier of the customer whose payment methods to retrieve.
+     * @return A pair of the list of payment methods and a networking error.
+     */
     suspend fun getPaymentMethodsWithCustomer(customerId: String): Pair<List<FrameObjects.PaymentMethod>?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethodsWithCustomer(customerId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<PaymentMethodResponses.ListPaymentMethodsResponse>(data)?.data }, error)
     }
 
+    /**
+     * Fetches all payment methods associated with a specific merchant account.
+     *
+     * @param accountId The unique identifier of the account whose payment methods to retrieve.
+     * @return A pair of the list of payment methods and a networking error.
+     */
     suspend fun getPaymentMethodsWithAccount(accountId: String): Pair<List<FrameObjects.PaymentMethod>?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethodsWithAccount(accountId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<PaymentMethodResponses.ListPaymentMethodsResponse>(data)?.data }, error)
     }
 
+    /**
+     * Creates a new card payment method, optionally encrypting sensitive fields via Evervault.
+     *
+     * When [encryptData] is true, [PaymentMethodRequests.CreateCardPaymentMethodRequest.cardNumber]
+     * and [PaymentMethodRequests.CreateCardPaymentMethodRequest.cvc] are encrypted before the
+     * request is sent.
+     *
+     * @param request The card details and optional customer or account associations.
+     * @param encryptData Whether to encrypt the card number and CVC before transmission. Defaults to true.
+     * @return A pair of the created payment method and a networking error.
+     */
     suspend fun createCardPaymentMethod(request: PaymentMethodRequests.CreateCardPaymentMethodRequest, encryptData: Boolean = true): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         if (!FrameNetworking.isEvervaultConfigured && encryptData) {
             FrameNetworking.configureEvervault()
@@ -49,48 +93,100 @@ object PaymentMethodsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Creates a new ACH bank-account payment method.
+     *
+     * @param request The ACH bank account details and optional customer or account associations.
+     * @return A pair of the created payment method and a networking error.
+     */
     suspend fun createACHPaymentMethod(request: PaymentMethodRequests.CreateACHPaymentMethodRequest): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.CreatePaymentMethod
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Updates mutable fields on an existing payment method.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to update.
+     * @param request The fields to update (expiration date and/or billing address).
+     * @return A pair of the updated payment method and a networking error.
+     */
     suspend fun updatePaymentMethodWith(paymentMethodId: String, request: PaymentMethodRequests.UpdatePaymentMethodRequest): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.UpdatePaymentMethodWith(paymentMethodId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Attaches a payment method to a customer or merchant account.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to attach.
+     * @param request The customer and/or account to attach the payment method to.
+     * @return A pair of the updated payment method and a networking error.
+     */
     suspend fun attachPaymentMethodWith(paymentMethodId: String, request: PaymentMethodRequests.AttachPaymentMethodRequest):Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.AttachPaymentMethodWith(paymentMethodId = paymentMethodId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Detaches a payment method from its associated customer or account.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to detach.
+     * @return A pair of the updated payment method and a networking error.
+     */
     suspend fun detachPaymentMethodWith(paymentMethodId: String): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.DetachPaymentMethodWith(paymentMethodId = paymentMethodId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(description = null))
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Blocks a payment method, preventing it from being used for new transactions.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to block.
+     * @return A pair of the updated payment method and a networking error.
+     */
     suspend fun blockPaymentMethodWith(paymentMethodId: String): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.BlockPaymentMethodWith(paymentMethodId = paymentMethodId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(description = null))
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Unblocks a previously blocked payment method, restoring its ability to be used for transactions.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to unblock.
+     * @return A pair of the updated payment method and a networking error.
+     */
     suspend fun unblockPaymentMethodWith(paymentMethodId: String): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.UnblockPaymentMethodWith(paymentMethodId = paymentMethodId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(description = null))
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
 
+    /**
+     * Creates a new payment method from a Google Pay wallet token.
+     *
+     * Sends the request using the merchant's publishable key rather than the secret key.
+     *
+     * @param request The Google Pay wallet data and optional customer or account associations.
+     * @return A pair of the created payment method and a networking error.
+     */
     suspend fun createGooglePayPaymentMethod(request: PaymentMethodRequests.CreateGooglePayPaymentMethodRequest): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.CreatePaymentMethod
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request, usePublishableKey = true)
         return Pair(data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error)
     }
-    
+
+    /**
+     * Creates a new ACH payment method by connecting a bank account via Plaid.
+     *
+     * @param request The Plaid public token, account identifier, and optional institution metadata.
+     * @return A pair of the created payment method and a networking error.
+     */
     suspend fun connectPlaidBankAccount(request: PaymentMethodRequests.ConnectPlaidBankAccountRequest): Pair<FrameObjects.PaymentMethod?, NetworkingError?> {
         val endpoint = PaymentMethodEndpoints.ConnectPlaidBankAccount
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -98,6 +194,14 @@ object PaymentMethodsAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Fetches a paginated list of payment methods and delivers the result to a callback.
+     *
+     * @param page 1-based page number to retrieve, or null for the server default.
+     * @param perPage Number of results per page, or null for the server default.
+     * @param completionHandler Called with the paginated response on success, or a [NetworkingError] on failure.
+     */
     fun getPaymentMethods(page: Int? = null, perPage: Int? = null, completionHandler: (PaymentMethodResponses.ListPaymentMethodsResponse?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethods(perPage = perPage, page = page)
 
@@ -106,6 +210,12 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Fetches a single payment method by its unique identifier and delivers the result to a callback.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to retrieve.
+     * @param completionHandler Called with the matching payment method on success, or a [NetworkingError] on failure.
+     */
     fun getPaymentMethodWith(paymentMethodId: String, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethodWith(paymentMethodId = paymentMethodId)
 
@@ -114,6 +224,12 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Fetches all payment methods for a customer and delivers the result to a callback.
+     *
+     * @param customerId The unique identifier of the customer whose payment methods to retrieve.
+     * @param completionHandler Called with the list of payment methods on success, or a [NetworkingError] on failure.
+     */
     fun getPaymentMethodsWithCustomer(customerId: String, completionHandler: (List<FrameObjects.PaymentMethod>?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethodsWithCustomer(customerId)
         FrameNetworking.performDataTask(endpoint) { data, error ->
@@ -121,6 +237,12 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Fetches all payment methods for a merchant account and delivers the result to a callback.
+     *
+     * @param accountId The unique identifier of the account whose payment methods to retrieve.
+     * @param completionHandler Called with the list of payment methods on success, or a [NetworkingError] on failure.
+     */
     fun getPaymentMethodsWithAccount(accountId: String, completionHandler: (List<FrameObjects.PaymentMethod>?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.GetPaymentMethodsWithAccount(accountId)
         FrameNetworking.performDataTask(endpoint) { data, error ->
@@ -128,6 +250,17 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Creates a new card payment method on the provided coroutine scope and delivers the result to a callback on the main thread.
+     *
+     * When [encryptData] is true, the card number and CVC are encrypted via Evervault before
+     * transmission. The completion handler is always invoked on the main dispatcher.
+     *
+     * @param request The card details and optional customer or account associations.
+     * @param encryptData Whether to encrypt the card number and CVC before transmission. Defaults to true.
+     * @param scope The [CoroutineScope] on which the encryption and network work is launched.
+     * @param completionHandler Called on the main thread with the created payment method on success, or a [NetworkingError] on failure.
+     */
     fun createCardPaymentMethod(request: PaymentMethodRequests.CreateCardPaymentMethodRequest, encryptData: Boolean = true, scope: CoroutineScope, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         if (!FrameNetworking.isEvervaultConfigured) {
             FrameNetworking.configureEvervault()
@@ -148,6 +281,13 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Creates a new ACH payment method and delivers the result to a callback.
+     *
+     * @param request The ACH bank account details and optional customer or account associations.
+     * @param scope The [CoroutineScope] used for the network operation (unused internally but kept for API consistency).
+     * @param completionHandler Called with the created payment method on success, or a [NetworkingError] on failure.
+     */
     fun createACHPaymentMethod(request: PaymentMethodRequests.CreateACHPaymentMethodRequest, scope: CoroutineScope, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.CreatePaymentMethod
 
@@ -156,6 +296,13 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Updates mutable fields on an existing payment method and delivers the result to a callback.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to update.
+     * @param request The fields to update (expiration date and/or billing address).
+     * @param completionHandler Called with the updated payment method on success, or a [NetworkingError] on failure.
+     */
     fun updatePaymentMethodWith(paymentMethodId: String, request: PaymentMethodRequests.UpdatePaymentMethodRequest, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.UpdatePaymentMethodWith(paymentMethodId)
 
@@ -164,6 +311,13 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Attaches a payment method to a customer or merchant account and delivers the result to a callback.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to attach.
+     * @param request The customer and/or account to attach the payment method to.
+     * @param completionHandler Called with the updated payment method on success, or a [NetworkingError] on failure.
+     */
     fun attachPaymentMethodWith(paymentMethodId: String, request: PaymentMethodRequests.AttachPaymentMethodRequest, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.AttachPaymentMethodWith(paymentMethodId)
 
@@ -172,6 +326,12 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Detaches a payment method from its associated customer or account and delivers the result to a callback.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to detach.
+     * @param completionHandler Called with the updated payment method on success, or a [NetworkingError] on failure.
+     */
     fun detachPaymentMethodWith(paymentMethodId: String, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.DetachPaymentMethodWith(paymentMethodId)
 
@@ -180,6 +340,12 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Blocks a payment method and delivers the result to a callback.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to block.
+     * @param completionHandler Called with the updated payment method on success, or a [NetworkingError] on failure.
+     */
     fun blockPaymentMethodWith(paymentMethodId: String, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.BlockPaymentMethodWith(paymentMethodId)
 
@@ -188,6 +354,12 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Unblocks a previously blocked payment method and delivers the result to a callback.
+     *
+     * @param paymentMethodId The unique identifier of the payment method to unblock.
+     * @param completionHandler Called with the updated payment method on success, or a [NetworkingError] on failure.
+     */
     fun unblockPaymentMethodWith(paymentMethodId: String, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.UnblockPaymentMethodWith(paymentMethodId)
 
@@ -196,6 +368,14 @@ object PaymentMethodsAPI {
         }
     }
 
+    /**
+     * Creates a new payment method from a Google Pay wallet token and delivers the result to a callback.
+     *
+     * Sends the request using the merchant's publishable key rather than the secret key.
+     *
+     * @param request The Google Pay wallet data and optional customer or account associations.
+     * @param completionHandler Called with the created payment method on success, or a [NetworkingError] on failure.
+     */
     fun createGooglePayPaymentMethod(request: PaymentMethodRequests.CreateGooglePayPaymentMethodRequest, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.CreatePaymentMethod
 
@@ -203,7 +383,13 @@ object PaymentMethodsAPI {
             completionHandler( data?.let { FrameNetworking.parseResponse<FrameObjects.PaymentMethod>(data) }, error )
         }
     }
-    
+
+    /**
+     * Creates a new ACH payment method by connecting a bank account via Plaid and delivers the result to a callback.
+     *
+     * @param request The Plaid public token, account identifier, and optional institution metadata.
+     * @param completionHandler Called with the created payment method on success, or a [NetworkingError] on failure.
+     */
     fun connectPlaidBankAccount(request: PaymentMethodRequests.ConnectPlaidBankAccountRequest, completionHandler: (FrameObjects.PaymentMethod?, NetworkingError?) -> Unit) {
         val endpoint = PaymentMethodEndpoints.ConnectPlaidBankAccount
         FrameNetworking.performDataTaskWithRequest(endpoint, request) { data, error ->

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhaseEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhaseEndpoints.kt
@@ -3,12 +3,57 @@ package com.framepayments.framesdk.productphases
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints available for product phase operations.
+ *
+ * Each case maps to a specific URL, HTTP method, and optional query parameters
+ * used by the networking layer to build requests.
+ */
 sealed class ProductPhaseEndpoints: FrameNetworkingEndpoints {
+
+    /**
+     * Endpoint for retrieving all phases of a product (`GET /v1/products/{productId}/phases`).
+     *
+     * @property productId The unique identifier of the product whose phases to retrieve.
+     */
     data class GetProductPhases(val productId: String): ProductPhaseEndpoints()
+
+    /**
+     * Endpoint for retrieving a specific phase by identifier (`GET /v1/products/{productId}/phases/{phaseId}`).
+     *
+     * @property productId The unique identifier of the product that owns the phase.
+     * @property phaseId The unique identifier of the phase to retrieve.
+     */
     data class GetProductPhaseWith(val productId: String, val phaseId: String): ProductPhaseEndpoints()
+
+    /**
+     * Endpoint for creating a new phase on a product (`POST /v1/products/{productId}/phases`).
+     *
+     * @property productId The unique identifier of the product to add a phase to.
+     */
     data class CreateProductPhase(val productId: String): ProductPhaseEndpoints()
+
+    /**
+     * Endpoint for updating a specific phase on a product (`PATCH /v1/products/{productId}/phases/{phaseId}`).
+     *
+     * @property productId The unique identifier of the product that owns the phase.
+     * @property phaseId The unique identifier of the phase to update.
+     */
     data class UpdateProductPhase(val productId: String, val phaseId: String): ProductPhaseEndpoints()
+
+    /**
+     * Endpoint for deleting a specific phase from a product (`DELETE /v1/products/{productId}/phases/{phaseId}`).
+     *
+     * @property productId The unique identifier of the product that owns the phase.
+     * @property phaseId The unique identifier of the phase to delete.
+     */
     data class DeleteProductPhase(val productId: String, val phaseId: String): ProductPhaseEndpoints()
+
+    /**
+     * Endpoint for replacing all phases on a product in a single request (`PATCH /v1/products/{productId}/phases/bulk_update`).
+     *
+     * @property productId The unique identifier of the product whose phases to replace.
+     */
     data class BulkUpdateProductPhases(val productId: String): ProductPhaseEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhaseRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhaseRequests.kt
@@ -4,7 +4,21 @@ import com.framepayments.framesdk.subscriptionphases.PhasePricingType
 import com.framepayments.framesdk.subscriptionphases.SubscriptionPhase
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains request body models for the Product Phases API.
+ */
 object ProductPhaseRequest {
+
+    /**
+     * Request body for creating a new phase on a product.
+     *
+     * @property ordinal The zero-based position of this phase in the product's phase sequence.
+     * @property name Optional display name for the phase.
+     * @property pricingType The pricing strategy applied during this phase.
+     * @property amountCents The fixed price for this phase in the smallest currency unit (e.g. cents). Used when [pricingType] is not discount-based.
+     * @property discountPercentage The percentage discount applied during this phase. Required when [pricingType] is [PhasePricingType.STATIC].
+     * @property periodCount The number of billing periods this phase lasts before advancing to the next phase.
+     */
     data class CreateProductPhaseRequest(
         val ordinal: Int,
         val name: String?,
@@ -14,6 +28,18 @@ object ProductPhaseRequest {
         @SerializedName("period_count") val periodCount: Int?
     )
 
+    /**
+     * Request body for updating an existing phase on a product.
+     *
+     * All fields are optional; only non-null fields are applied to the phase.
+     *
+     * @property ordinal Updated zero-based position of this phase in the product's phase sequence.
+     * @property name Updated display name for the phase.
+     * @property pricingType Updated pricing strategy applied during this phase.
+     * @property amountCents Updated fixed price for this phase in the smallest currency unit (e.g. cents).
+     * @property discountPercentage Updated percentage discount applied during this phase.
+     * @property periodCount Updated number of billing periods this phase lasts.
+     */
     data class UpdateProductPhaseRequest(
         val ordinal: Int? = null,
         val name: String? = null,
@@ -23,6 +49,11 @@ object ProductPhaseRequest {
         @SerializedName("period_count") val periodCount: Int? = null
     )
 
+    /**
+     * Request body for replacing all phases on a product in a single operation.
+     *
+     * @property phases The complete ordered list of [SubscriptionPhase] objects to apply to the product.
+     */
     data class BulkUpdateProductPhaseRequest(
         val phases: List<SubscriptionPhase>
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhaseResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhaseResponses.kt
@@ -3,11 +3,23 @@ package com.framepayments.framesdk.productphases
 import com.framepayments.framesdk.subscriptionphases.SubscriptionPhase
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Response returned when retrieving or bulk-updating the phases of a product.
+ *
+ * @property phases The list of [SubscriptionPhase] objects associated with the product.
+ * @property meta Metadata describing the result, such as the owning product and update count.
+ */
 data class ListProductPhaseResponse(
     val phases: List<SubscriptionPhase>?,
     val meta: MetaProductPhaseResponse?
 )
 
+/**
+ * Metadata included in a product phase list or bulk-update response.
+ *
+ * @property productId The unique identifier of the product that owns the returned phases.
+ * @property updatedCount The number of phases that were modified during a bulk-update operation.
+ */
 data class MetaProductPhaseResponse(
     @SerializedName("product_id") val productId: String?,
     @SerializedName("updated_count") val updatedCount: Int?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhasesAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/productphases/ProductPhasesAPI.kt
@@ -4,38 +4,88 @@ import com.framepayments.framesdk.subscriptionphases.SubscriptionPhase
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based methods for managing pricing phases on products.
+ *
+ * Product phases define the billing stages of a subscription-based product. Each operation
+ * has two overloads: a coroutine-based suspend function that returns a [Pair] and a
+ * callback-based variant for use outside of coroutine scopes.
+ */
 object ProductPhasesAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new phase for a product.
+     *
+     * @param productId The unique identifier of the product to add a phase to.
+     * @param request The phase attributes to create.
+     * @return A [Pair] containing the created [SubscriptionPhase] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createProductPhase(productId: String, request: ProductPhaseRequest.CreateProductPhaseRequest): Pair<SubscriptionPhase?, NetworkingError?> {
         val endpoint = ProductPhaseEndpoints.CreateProductPhase(productId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(FrameNetworking.parseResponse<SubscriptionPhase>(data), error)
     }
 
+    /**
+     * Updates a specific phase on a product.
+     *
+     * @param productId The unique identifier of the product that owns the phase.
+     * @param phaseId The unique identifier of the phase to update.
+     * @param request The phase attributes to update.
+     * @return A [Pair] containing the updated [SubscriptionPhase] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateProductPhase(productId: String, phaseId: String, request: ProductPhaseRequest.UpdateProductPhaseRequest): Pair<SubscriptionPhase?, NetworkingError?> {
         val endpoint = ProductPhaseEndpoints.UpdateProductPhase(productId, phaseId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(FrameNetworking.parseResponse<SubscriptionPhase>(data), error)
     }
 
+    /**
+     * Retrieves a specific phase on a product by its identifier.
+     *
+     * @param productId The unique identifier of the product that owns the phase.
+     * @param phaseId The unique identifier of the phase to retrieve.
+     * @return A [Pair] containing the matching [SubscriptionPhase] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getProductPhaseWith(productId: String, phaseId: String): Pair<SubscriptionPhase?, NetworkingError?> {
         val endpoint = ProductPhaseEndpoints.GetProductPhaseWith(productId, phaseId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(FrameNetworking.parseResponse<SubscriptionPhase>(data), error)
     }
 
+    /**
+     * Retrieves all phases associated with a product.
+     *
+     * @param productId The unique identifier of the product whose phases to retrieve.
+     * @return A [Pair] containing a [ListProductPhaseResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getProductPhases(productId: String): Pair<ListProductPhaseResponse?, NetworkingError?> {
         val endpoint = ProductPhaseEndpoints.GetProductPhases(productId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(FrameNetworking.parseResponse<ListProductPhaseResponse>(data), error)
     }
 
+    /**
+     * Replaces all phases on a product in a single request.
+     *
+     * @param productId The unique identifier of the product whose phases to replace.
+     * @param request The complete set of phases to apply to the product.
+     * @return A [Pair] containing a [ListProductPhaseResponse] reflecting the updated phases on success, or a [NetworkingError] on failure.
+     */
     suspend fun bulkUpdateProductPhases(productId: String, request: ProductPhaseRequest.BulkUpdateProductPhaseRequest) : Pair<ListProductPhaseResponse?, NetworkingError?> {
         val endpoint = ProductPhaseEndpoints.BulkUpdateProductPhases(productId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(FrameNetworking.parseResponse<ListProductPhaseResponse>(data), error)
     }
 
+    /**
+     * Deletes a specific phase from a product.
+     *
+     * @param productId The unique identifier of the product that owns the phase.
+     * @param phaseId The unique identifier of the phase to delete.
+     * @return A [NetworkingError] if the request failed, or null on success.
+     */
     suspend fun deleteProductPhaseWith(productId: String, phaseId: String): NetworkingError? {
         val endpoint = ProductPhaseEndpoints.DeleteProductPhase(productId, phaseId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -43,6 +93,14 @@ object ProductPhasesAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new phase for a product and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product to add a phase to.
+     * @param request The phase attributes to create.
+     * @param completionHandler Invoked with the created [SubscriptionPhase] on success, or a [NetworkingError] on failure.
+     */
     fun createProductPhase(productId: String, request: ProductPhaseRequest.CreateProductPhaseRequest, completionHandler: (SubscriptionPhase?, NetworkingError?) -> Unit) {
         val endpoint = ProductPhaseEndpoints.CreateProductPhase(productId)
 
@@ -51,6 +109,14 @@ object ProductPhasesAPI {
         }
     }
 
+    /**
+     * Updates a specific phase on a product and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product that owns the phase.
+     * @param phaseId The unique identifier of the phase to update.
+     * @param request The phase attributes to update.
+     * @param completionHandler Invoked with the updated [SubscriptionPhase] on success, or a [NetworkingError] on failure.
+     */
     fun updateProductPhase(productId: String, phaseId: String, request: ProductPhaseRequest.UpdateProductPhaseRequest, completionHandler: (SubscriptionPhase?, NetworkingError?) -> Unit) {
         val endpoint = ProductPhaseEndpoints.UpdateProductPhase(productId, phaseId)
 
@@ -59,6 +125,13 @@ object ProductPhasesAPI {
         }
     }
 
+    /**
+     * Retrieves a specific phase on a product by its identifier and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product that owns the phase.
+     * @param phaseId The unique identifier of the phase to retrieve.
+     * @param completionHandler Invoked with the matching [SubscriptionPhase] on success, or a [NetworkingError] on failure.
+     */
     fun getProductWith(productId: String, phaseId: String, completionHandler: (SubscriptionPhase?, NetworkingError?) -> Unit) {
         val endpoint = ProductPhaseEndpoints.GetProductPhaseWith(productId, phaseId)
 
@@ -67,6 +140,12 @@ object ProductPhasesAPI {
         }
     }
 
+    /**
+     * Retrieves all phases associated with a product and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product whose phases to retrieve.
+     * @param completionHandler Invoked with a [ListProductPhaseResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getProducts(productId: String, completionHandler: (ListProductPhaseResponse?, NetworkingError?) -> Unit) {
         val endpoint = ProductPhaseEndpoints.GetProductPhases(productId)
 
@@ -75,6 +154,13 @@ object ProductPhasesAPI {
         }
     }
 
+    /**
+     * Replaces all phases on a product in a single request and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product whose phases to replace.
+     * @param request The complete set of phases to apply to the product.
+     * @param completionHandler Invoked with a [ListProductPhaseResponse] reflecting the updated phases on success, or a [NetworkingError] on failure.
+     */
     fun bulkUpdateProductPhases(productId: String, request: ProductPhaseRequest.BulkUpdateProductPhaseRequest, completionHandler: (ListProductPhaseResponse?, NetworkingError?) -> Unit) {
         val endpoint = ProductPhaseEndpoints.BulkUpdateProductPhases(productId)
 
@@ -83,6 +169,13 @@ object ProductPhasesAPI {
         }
     }
 
+    /**
+     * Deletes a specific phase from a product and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product that owns the phase.
+     * @param phaseId The unique identifier of the phase to delete.
+     * @param completionHandler Invoked with a [NetworkingError] if the request failed, or null on success.
+     */
     fun deleteProductPhaseWith(productId: String, phaseId: String, completionHandler: (NetworkingError?) -> Unit) {
         val endpoint = ProductPhaseEndpoints.DeleteProductPhase(productId, phaseId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductEndpoints.kt
@@ -3,12 +3,53 @@ package com.framepayments.framesdk.products
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints available for product operations.
+ *
+ * Each case maps to a specific URL, HTTP method, and optional query parameters
+ * used by the networking layer to build requests.
+ */
 sealed class ProductEndpoints : FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new product (`POST /v1/products`). */
     object CreateProduct: ProductEndpoints()
+
+    /**
+     * Endpoint for updating an existing product (`PATCH /v1/products/{productId}`).
+     *
+     * @property productId The unique identifier of the product to update.
+     */
     data class UpdateProduct(val productId: String): ProductEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated list of products (`GET /v1/products`).
+     *
+     * @property perPage The number of products to return per page.
+     * @property page The page number to retrieve.
+     */
     data class GetProducts(val perPage: Int? = null, val page: Int? = null): ProductEndpoints()
+
+    /**
+     * Endpoint for retrieving a single product by identifier (`GET /v1/products/{productId}`).
+     *
+     * @property productId The unique identifier of the product to retrieve.
+     */
     data class GetProductWith(val productId: String): ProductEndpoints()
+
+    /**
+     * Endpoint for searching products by filter criteria (`GET /v1/products/search`).
+     *
+     * @property name Filters results to products whose name matches this value.
+     * @property active Filters results to active or inactive products.
+     * @property shippable Filters results to shippable or non-shippable products.
+     */
     data class SearchProducts(val name: String? = null, val active: Boolean? = null, val shippable: Boolean? = null): ProductEndpoints()
+
+    /**
+     * Endpoint for deleting a product (`DELETE /v1/products/{productId}`).
+     *
+     * @property productId The unique identifier of the product to delete.
+     */
     data class DeleteProduct(val productId: String): ProductEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductObjects.kt
@@ -2,20 +2,51 @@ package com.framepayments.framesdk.products
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Indicates whether a product is purchased once or on a recurring basis.
+ */
 enum class ProductPurchaseType {
+    /** The customer is charged a single time at purchase. */
     @SerializedName("one_time") ONE_TIME,
+    /** The customer is charged repeatedly on a defined interval. */
     @SerializedName("recurring") RECURRING
 }
 
+/**
+ * Defines the billing cadence for a recurring product.
+ */
 enum class ProductRecurringInterval {
+    /** Billed once per day. */
     @SerializedName("daily") DAILY,
+    /** Billed once per week. */
     @SerializedName("weekly") WEEKLY,
+    /** Billed once per month. */
     @SerializedName("monthly") MONTHLY,
+    /** Billed once per year. */
     @SerializedName("yearly") YEARLY,
+    /** Billed once every three months. */
     @SerializedName("every_3_months") EVERY_3_MONTHS,
+    /** Billed once every six months. */
     @SerializedName("every_6_months") EVERY_6_MONTHS,
 }
 
+/**
+ * Represents a product defined by the merchant in the Frame platform.
+ *
+ * @property id Unique identifier for the product.
+ * @property name Display name of the product.
+ * @property livemode Whether the product was created in live mode (`true`) or test mode (`false`).
+ * @property image URL of the product image.
+ * @property description Human-readable description of the product.
+ * @property url URL for the product's external page or listing.
+ * @property shippable Whether the product requires physical shipment to the customer.
+ * @property active Whether the product is currently available for purchase.
+ * @property metadata Merchant-defined key-value pairs attached to the product.
+ * @property created Unix timestamp of when the product was created.
+ * @property updated Unix timestamp of when the product was last updated.
+ * @property defaultPrice The default price for the product, in the smallest currency unit (e.g. cents).
+ * @property productObject The object type identifier returned by the API (typically `"product"`).
+ */
 data class Product(
     val id: String?,
     val name: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductsAPI.kt
@@ -3,38 +3,85 @@ package com.framepayments.framesdk.products
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based methods for managing products in the Frame API.
+ *
+ * Each operation has two overloads: a coroutine-based suspend function that returns a [Pair]
+ * and a callback-based variant for use outside of coroutine scopes.
+ */
 object ProductsAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new product.
+     *
+     * @param request The product attributes to create.
+     * @return A [Pair] containing the created [Product] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createProduct(request: ProductsRequests.CreateProductRequest): Pair<Product?, NetworkingError?> {
         val endpoint = ProductEndpoints.CreateProduct
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Product>(data) }, error)
     }
 
+    /**
+     * Updates an existing product.
+     *
+     * @param productId The unique identifier of the product to update.
+     * @param request The product attributes to update.
+     * @return A [Pair] containing the updated [Product] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateProduct(productId: String, request: ProductsRequests.UpdateProductRequest): Pair<Product?, NetworkingError?> {
         val endpoint = ProductEndpoints.UpdateProduct(productId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Product>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of products.
+     *
+     * @param page The page number to retrieve. Defaults to the first page when null.
+     * @param perPage The number of products to return per page. Uses the API default when null.
+     * @return A [Pair] containing a [ProductsResponses.ListProductsResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getProducts(page: Int? = null, perPage: Int? = null): Pair<ProductsResponses.ListProductsResponse?, NetworkingError?> {
         val endpoint = ProductEndpoints.GetProducts(perPage = perPage, page = page)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<ProductsResponses.ListProductsResponse>(data) }, error)
     }
 
+    /**
+     * Retrieves a single product by its identifier.
+     *
+     * @param productId The unique identifier of the product to retrieve.
+     * @return A [Pair] containing the matching [Product] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getProductWith(productId: String): Pair<Product?, NetworkingError?> {
         val endpoint = ProductEndpoints.GetProductWith(productId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<Product>(data) }, error)
     }
 
+    /**
+     * Searches products by optional filter criteria.
+     *
+     * @param name Filters results to products whose name matches this value. Omitted when null.
+     * @param active Filters results to active or inactive products. Omitted when null.
+     * @param shippable Filters results to shippable or non-shippable products. Omitted when null.
+     * @return A [Pair] containing the matching list of [Product] objects on success, or a [NetworkingError] on failure.
+     */
     suspend fun searchProducts(name: String? = null, active: Boolean? = null, shippable: Boolean? = null): Pair<List<Product>?, NetworkingError?> {
         val endpoint = ProductEndpoints.SearchProducts(name, active, shippable)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<ProductsResponses.ListProductsResponse>(data)?.data }, error)
     }
 
+    /**
+     * Deletes a product by its identifier.
+     *
+     * @param productId The unique identifier of the product to delete.
+     * @return A [Pair] containing a [ProductsResponses.DeleteProductsResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun deleteProduct(productId: String): Pair<ProductsResponses.DeleteProductsResponse?, NetworkingError?> {
         val endpoint = ProductEndpoints.DeleteProduct(productId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -42,6 +89,13 @@ object ProductsAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new product and delivers the result via a callback.
+     *
+     * @param request The product attributes to create.
+     * @param completionHandler Invoked with the created [Product] on success, or a [NetworkingError] on failure.
+     */
     fun createProduct(request: ProductsRequests.CreateProductRequest, completionHandler: (Product?, NetworkingError?) -> Unit) {
         val endpoint = ProductEndpoints.CreateProduct
 
@@ -50,6 +104,13 @@ object ProductsAPI {
         }
     }
 
+    /**
+     * Updates an existing product and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product to update.
+     * @param request The product attributes to update.
+     * @param completionHandler Invoked with the updated [Product] on success, or a [NetworkingError] on failure.
+     */
     fun updateProduct(productId: String, request: ProductsRequests.UpdateProductRequest, completionHandler: (Product?, NetworkingError?) -> Unit) {
         val endpoint = ProductEndpoints.UpdateProduct(productId)
 
@@ -58,6 +119,13 @@ object ProductsAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of products and delivers the result via a callback.
+     *
+     * @param page The page number to retrieve. Defaults to the first page when null.
+     * @param perPage The number of products to return per page. Uses the API default when null.
+     * @param completionHandler Invoked with a [ProductsResponses.ListProductsResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getProducts(page: Int? = null, perPage: Int? = null, completionHandler: (ProductsResponses.ListProductsResponse?, NetworkingError?) -> Unit) {
         val endpoint = ProductEndpoints.GetProducts(perPage = perPage, page = page)
 
@@ -66,6 +134,12 @@ object ProductsAPI {
         }
     }
 
+    /**
+     * Retrieves a single product by its identifier and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product to retrieve.
+     * @param completionHandler Invoked with the matching [Product] on success, or a [NetworkingError] on failure.
+     */
     fun getProductWith(productId: String, completionHandler: (Product?, NetworkingError?) -> Unit) {
         val endpoint = ProductEndpoints.GetProductWith(productId)
 
@@ -74,6 +148,14 @@ object ProductsAPI {
         }
     }
 
+    /**
+     * Searches products by optional filter criteria and delivers the result via a callback.
+     *
+     * @param name Filters results to products whose name matches this value. Omitted when null.
+     * @param active Filters results to active or inactive products. Omitted when null.
+     * @param shippable Filters results to shippable or non-shippable products. Omitted when null.
+     * @param completionHandler Invoked with the matching list of [Product] objects on success, or a [NetworkingError] on failure.
+     */
     fun searchProducts(name: String? = null, active: Boolean? = null, shippable: Boolean? = null, completionHandler: (List<Product>?, NetworkingError?) -> Unit) {
         val endpoint = ProductEndpoints.SearchProducts(name, active, shippable)
 
@@ -82,6 +164,12 @@ object ProductsAPI {
         }
     }
 
+    /**
+     * Deletes a product by its identifier and delivers the result via a callback.
+     *
+     * @param productId The unique identifier of the product to delete.
+     * @param completionHandler Invoked with a [ProductsResponses.DeleteProductsResponse] on success, or a [NetworkingError] on failure.
+     */
     fun deleteProduct(productId: String, completionHandler: (ProductsResponses.DeleteProductsResponse?, NetworkingError?) -> Unit) {
         val endpoint = ProductEndpoints.DeleteProduct(productId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductsRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductsRequests.kt
@@ -2,7 +2,23 @@ package com.framepayments.framesdk.products
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains request body models for the Products API.
+ */
 object ProductsRequests {
+
+    /**
+     * Request body for creating a new product.
+     *
+     * @property name Display name of the product.
+     * @property description Human-readable description of the product.
+     * @property defaultPrice Default price for the product, in the smallest currency unit (e.g. cents).
+     * @property purchaseType Whether the product is purchased once or on a recurring basis.
+     * @property recurringInterval The billing cadence for the product. Required when [purchaseType] is [ProductPurchaseType.RECURRING].
+     * @property shippable Whether the product requires physical shipment to the customer. Omitted when null.
+     * @property url URL for the product's external page or listing. Omitted when null.
+     * @property metadata Merchant-defined key-value pairs to attach to the product. Omitted when null.
+     */
     data class CreateProductRequest(
         val name: String,
         val description: String,
@@ -14,6 +30,18 @@ object ProductsRequests {
         val metadata: Map<String, String>?
     )
 
+    /**
+     * Request body for updating an existing product.
+     *
+     * All fields are optional; only non-null fields are applied to the product.
+     *
+     * @property name Updated display name of the product.
+     * @property description Updated human-readable description of the product.
+     * @property defaultPrice Updated default price, in the smallest currency unit (e.g. cents).
+     * @property shippable Updated shippable flag for the product.
+     * @property url Updated URL for the product's external page or listing.
+     * @property metadata Updated merchant-defined key-value pairs for the product.
+     */
     data class UpdateProductRequest(
         val name: String? = null,
         val description: String? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductsResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/products/ProductsResponses.kt
@@ -3,12 +3,29 @@ package com.framepayments.framesdk.products
 import com.framepayments.framesdk.FrameMetadata
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains response body models for the Products API.
+ */
 object ProductsResponses {
+
+    /**
+     * Response returned when retrieving a paginated list of products.
+     *
+     * @property meta Pagination metadata for the result set.
+     * @property data The list of [Product] objects returned by the API.
+     */
     data class ListProductsResponse(
         val meta: FrameMetadata? = null,
         val data: List<Product>? = null
     )
 
+    /**
+     * Response returned when a product is successfully deleted.
+     *
+     * @property id The unique identifier of the deleted product.
+     * @property productObject The object type identifier returned by the API (typically `"product"`).
+     * @property deleted Whether the product was successfully deleted.
+     */
     data class DeleteProductsResponse(
         val id: String?,
         @SerializedName("object") val productObject: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundEndpoints.kt
@@ -2,9 +2,31 @@ package com.framepayments.framesdk.refunds
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints available for refund operations.
+ *
+ * Each case maps to a specific URL path and HTTP method used by [FrameNetworking].
+ */
 sealed class RefundEndpoints : FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new refund via POST to `/v1/refunds`. */
     object CreateRefund : RefundEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated list of refunds via GET to `/v1/refunds`.
+     *
+     * @property chargeId Optional charge ID to filter results.
+     * @property chargeIntentId Optional charge intent ID to filter results.
+     * @property perPage Optional number of results per page.
+     * @property page Optional page number to retrieve.
+     */
     data class GetRefunds(val chargeId: String?, val chargeIntentId: String?, val perPage: Int?, val page : Int?) : RefundEndpoints()
+
+    /**
+     * Endpoint for retrieving a single refund via GET to `/v1/refunds/{refundId}`.
+     *
+     * @property refundId The unique ID of the refund to retrieve.
+     */
     data class GetRefundWith(val refundId: String) : RefundEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundObjects.kt
@@ -1,6 +1,22 @@
 package com.framepayments.framesdk.refunds
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents a refund issued against a charge or charge intent.
+ *
+ * @property id Unique identifier for the refund.
+ * @property charge ID of the charge this refund is applied to.
+ * @property currency Three-letter ISO currency code for the refund amount.
+ * @property description Optional description provided when the refund was created.
+ * @property status Current status of the refund (e.g., "succeeded", "pending", "failed").
+ * @property created Unix timestamp of when the refund was created.
+ * @property updated Unix timestamp of when the refund was last updated.
+ * @property amountCaptured Amount that was captured on the original charge, in the smallest currency unit.
+ * @property amountRefunded Amount refunded, in the smallest currency unit.
+ * @property chargeIntent ID of the charge intent associated with this refund.
+ * @property failureReason Reason for refund failure, if applicable.
+ * @property refundObject String identifier for the object type, always "refund".
+ */
 data class Refund(
     val id: String?,
     val charge: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundRequests.kt
@@ -1,7 +1,19 @@
 package com.framepayments.framesdk.refunds
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Namespace for request models used by the Refunds API.
+ */
 object RefundRequests {
+
+    /**
+     * Request body for creating a new refund.
+     *
+     * @property chargeIntent The ID of the charge intent to refund. Required.
+     * @property amount Amount to refund in the smallest currency unit (e.g., cents). Defaults to the full
+     *   captured amount when null.
+     * @property reason Optional reason for the refund (e.g., "duplicate", "fraudulent", "customer_request").
+     */
     data class CreateRefundRequest(
         @SerializedName("charge_intent") val chargeIntent: String,
         val amount: Int? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundResponses.kt
@@ -1,7 +1,17 @@
 package com.framepayments.framesdk.refunds
 import com.framepayments.framesdk.FrameMetadata
 
+/**
+ * Namespace for response models returned by the Refunds API.
+ */
 object RefundResponses {
+
+    /**
+     * Paginated response returned when listing refunds.
+     *
+     * @property meta Pagination metadata for the result set, or null if unavailable.
+     * @property data List of [Refund] objects for the current page, or null if unavailable.
+     */
     data class ListRefundsResponse (
         val meta: FrameMetadata?,
         val data: List<Refund>?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/refunds/RefundsAPI.kt
@@ -2,20 +2,48 @@ package com.framepayments.framesdk.refunds
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides methods for creating and retrieving refunds against existing charges.
+ *
+ * Each operation is available as a suspend function for coroutine-based callers
+ * and as a callback-based overload for Java or non-coroutine callers.
+ */
 object RefundsAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new refund for the specified charge intent.
+     *
+     * @param request The refund creation parameters, including the required charge intent ID.
+     * @return A pair containing the created [Refund] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createRefund(request: RefundRequests.CreateRefundRequest): Pair<Refund?, NetworkingError?> {
         val endpoint = RefundEndpoints.CreateRefund
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Refund>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of refunds, optionally filtered by charge or charge intent.
+     *
+     * @param chargeId Optional ID of the charge to filter refunds by.
+     * @param chargeIntentId Optional ID of the charge intent to filter refunds by.
+     * @param perPage Optional number of results to return per page.
+     * @param page Optional page number to retrieve.
+     * @return A pair containing a [RefundResponses.ListRefundsResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getRefunds(chargeId: String?, chargeIntentId: String?, perPage: Int?, page : Int?): Pair<RefundResponses.ListRefundsResponse?, NetworkingError?> {
         val endpoint = RefundEndpoints.GetRefunds(chargeId = chargeId, chargeIntentId = chargeIntentId, perPage = perPage, page = page)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<RefundResponses.ListRefundsResponse>(data) }, error)
     }
 
+    /**
+     * Retrieves a single refund by its unique identifier.
+     *
+     * @param refundId The unique ID of the refund to retrieve.
+     * @return A pair containing the matching [Refund] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getRefundWith(refundId: String): Pair<Refund?, NetworkingError?> {
         val endpoint = RefundEndpoints.GetRefundWith(refundId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -23,6 +51,13 @@ object RefundsAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new refund for the specified charge intent and delivers the result via callback.
+     *
+     * @param request The refund creation parameters, including the required charge intent ID.
+     * @param completionHandler Invoked with the created [Refund] on success, or a [NetworkingError] on failure.
+     */
     fun createRefund(request: RefundRequests.CreateRefundRequest, completionHandler: (Refund?, NetworkingError?) -> Unit) {
         val endpoint = RefundEndpoints.CreateRefund
 
@@ -31,6 +66,15 @@ object RefundsAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of refunds and delivers the result via callback.
+     *
+     * @param chargeId Optional ID of the charge to filter refunds by.
+     * @param chargeIntentId Optional ID of the charge intent to filter refunds by.
+     * @param perPage Optional number of results to return per page.
+     * @param page Optional page number to retrieve.
+     * @param completionHandler Invoked with a [RefundResponses.ListRefundsResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getRefunds(chargeId: String?, chargeIntentId: String?, perPage: Int?, page : Int?, completionHandler: (RefundResponses.ListRefundsResponse?, NetworkingError?) -> Unit) {
         val endpoint = RefundEndpoints.GetRefunds(chargeId = chargeId, chargeIntentId = chargeIntentId, perPage = perPage, page = page)
 
@@ -39,6 +83,12 @@ object RefundsAPI {
         }
     }
 
+    /**
+     * Retrieves a single refund by its unique identifier and delivers the result via callback.
+     *
+     * @param refundId The unique ID of the refund to retrieve.
+     * @param completionHandler Invoked with the matching [Refund] on success, or a [NetworkingError] on failure.
+     */
     fun getRefundWith(refundId: String, completionHandler: (Refund?, NetworkingError?) -> Unit) {
         val endpoint = RefundEndpoints.GetRefundWith(refundId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseEndpoints.kt
@@ -3,12 +3,57 @@ package com.framepayments.framesdk.subscriptionphases
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines all API endpoints for subscription phase operations.
+ *
+ * Each case carries the path parameters required to construct its URL and selects
+ * the appropriate HTTP method.
+ */
 sealed class SubscriptionPhaseEndpoints: FrameNetworkingEndpoints {
+
+    /**
+     * Retrieves all phases for a subscription. Resolves to GET /v1/subscriptions/{subscriptionId}/phases.
+     *
+     * @property subscriptionId The ID of the subscription whose phases to list.
+     */
     data class GetSubscriptionPhases(val subscriptionId: String): SubscriptionPhaseEndpoints()
+
+    /**
+     * Retrieves a single phase by ID. Resolves to GET /v1/subscriptions/{subscriptionId}/phases/{phaseId}.
+     *
+     * @property subscriptionId The ID of the subscription that owns the phase.
+     * @property phaseId The ID of the phase to retrieve.
+     */
     data class GetSubscriptionPhaseWith(val subscriptionId: String, val phaseId: String): SubscriptionPhaseEndpoints()
+
+    /**
+     * Creates a new phase on a subscription. Resolves to POST /v1/subscriptions/{subscriptionId}/phases.
+     *
+     * @property subscriptionId The ID of the subscription to add the phase to.
+     */
     data class CreateSubscriptionPhase(val subscriptionId: String): SubscriptionPhaseEndpoints()
+
+    /**
+     * Updates an existing phase on a subscription. Resolves to PATCH /v1/subscriptions/{subscriptionId}/phases/{phaseId}.
+     *
+     * @property subscriptionId The ID of the subscription that owns the phase.
+     * @property phaseId The ID of the phase to update.
+     */
     data class UpdateSubscriptionPhase(val subscriptionId: String, val phaseId: String): SubscriptionPhaseEndpoints()
+
+    /**
+     * Deletes a phase from a subscription. Resolves to DELETE /v1/subscriptions/{subscriptionId}/phases/{phaseId}.
+     *
+     * @property subscriptionId The ID of the subscription that owns the phase.
+     * @property phaseId The ID of the phase to delete.
+     */
     data class DeleteSubscriptionPhase(val subscriptionId: String, val phaseId: String): SubscriptionPhaseEndpoints()
+
+    /**
+     * Replaces all phases on a subscription in a single request. Resolves to PATCH /v1/subscriptions/{subscriptionId}/phases/bulk_update.
+     *
+     * @property subscriptionId The ID of the subscription whose phases to replace.
+     */
     data class BulkUpdateSubscriptionPhases(val subscriptionId: String): SubscriptionPhaseEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseObjects.kt
@@ -1,6 +1,25 @@
 package com.framepayments.framesdk.subscriptionphases
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents a single billing phase within a subscription.
+ *
+ * @property id Unique identifier for the phase.
+ * @property ordinal Position of this phase in the subscription's phase sequence.
+ * @property name Human-readable label for the phase.
+ * @property pricingType Determines whether the phase price is [PhasePricingType.RELATIVE] or [PhasePricingType.STATIC].
+ * @property durationType Determines whether the phase runs for a fixed period ([PhaseDurationType.FINITE]) or indefinitely ([PhaseDurationType.INFINITE]).
+ * @property amount Billed amount for the phase in the smallest currency unit.
+ * @property currency ISO 4217 currency code for the phase amount.
+ * @property discountPercentage Percentage discount applied to the phase amount, if any.
+ * @property periodCount Number of billing periods the phase spans when [durationType] is [PhaseDurationType.FINITE].
+ * @property interval Billing interval unit (e.g. "month", "year").
+ * @property intervalCount Number of interval units between each billing cycle.
+ * @property livemode True when the phase exists in live mode; false in test mode.
+ * @property created Unix timestamp of when the phase was created.
+ * @property updated Unix timestamp of when the phase was last updated.
+ * @property phaseObject API object type identifier, typically "subscription_phase".
+ */
 data class SubscriptionPhase (
     val id: String?,
     val ordinal: Int?,
@@ -19,12 +38,24 @@ data class SubscriptionPhase (
     @SerializedName("object") val phaseObject: String?
 )
 
+/**
+ * Specifies how the price of a subscription phase is calculated.
+ */
 enum class PhasePricingType {
+    /** Price is calculated relative to the base plan price. */
     @SerializedName("relative") RELATIVE,
+
+    /** Price is a fixed amount regardless of the base plan. */
     @SerializedName("static") STATIC
 }
 
+/**
+ * Specifies how long a subscription phase runs.
+ */
 enum class PhaseDurationType {
+    /** Phase ends after a defined number of billing periods. */
     @SerializedName("finite") FINITE,
+
+    /** Phase continues indefinitely until cancelled or superseded. */
     @SerializedName("infinite") INFINITE
 }

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseRequests.kt
@@ -2,7 +2,24 @@ package com.framepayments.framesdk.subscriptionphases
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Namespace for request bodies used with the subscription phases API.
+ */
 object SubscriptionPhaseRequest {
+
+    /**
+     * Request body for creating a new subscription phase.
+     *
+     * @property ordinal Position of this phase in the subscription's phase sequence.
+     * @property pricingType Pricing strategy for the phase.
+     * @property durationType Whether the phase is finite or infinite.
+     * @property name Human-readable label for the phase.
+     * @property amountCents Billed amount in the smallest currency unit (e.g. cents).
+     * @property discountPercentage Percentage discount to apply to the phase amount.
+     * @property periodCount Number of billing periods the phase spans; required when [durationType] is [PhaseDurationType.FINITE].
+     * @property interval Billing interval unit (e.g. "month", "year").
+     * @property intervalCount Number of interval units between each billing cycle.
+     */
     data class CreateSubscriptionPhaseRequest(
         val ordinal: Int,
         @SerializedName("pricing_type") val pricingType: PhasePricingType,
@@ -15,6 +32,21 @@ object SubscriptionPhaseRequest {
         @SerializedName("interval_count") val intervalCount: Int?
     )
 
+    /**
+     * Request body for partially updating an existing subscription phase.
+     *
+     * Only non-null fields are sent to the API; omitted fields remain unchanged.
+     *
+     * @property ordinal Updated position of the phase in the subscription's phase sequence.
+     * @property pricingType Updated pricing strategy for the phase.
+     * @property durationType Updated duration type for the phase.
+     * @property name Updated human-readable label for the phase.
+     * @property amountCents Updated billed amount in the smallest currency unit.
+     * @property discountPercentage Updated percentage discount for the phase.
+     * @property periodCount Updated number of billing periods for a finite phase.
+     * @property interval Updated billing interval unit.
+     * @property intervalCount Updated number of interval units between billing cycles.
+     */
     data class UpdateSubscriptionPhaseRequest(
         val ordinal: Int? = null,
         @SerializedName("pricing_type") val pricingType: PhasePricingType? = null,
@@ -27,6 +59,11 @@ object SubscriptionPhaseRequest {
         @SerializedName("interval_count") val intervalCount: Int? = null
     )
 
+    /**
+     * Request body for replacing all phases on a subscription in a single call.
+     *
+     * @property phases The complete ordered list of phases to apply to the subscription.
+     */
     data class BulkUpdateSubscriptionPhaseRequest(
         val phases: List<SubscriptionPhase>
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhaseResponses.kt
@@ -2,11 +2,22 @@ package com.framepayments.framesdk.subscriptionphases
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Response returned when listing all phases for a subscription.
+ *
+ * @property phases The list of [SubscriptionPhase] objects belonging to the subscription.
+ * @property meta Metadata associated with the response, including the parent subscription ID.
+ */
 data class ListSubscriptionPhaseResponse(
     val phases: List<SubscriptionPhase>?,
     val meta: MetaSubscriptionPhaseResponse?
 )
 
+/**
+ * Metadata included in a list subscription phases response.
+ *
+ * @property subscriptionId The ID of the subscription that owns the returned phases.
+ */
 data class MetaSubscriptionPhaseResponse(
     @SerializedName("subscription_id") val subscriptionId: String?
 )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhasesAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptionphases/SubscriptionPhasesAPI.kt
@@ -3,38 +3,84 @@ package com.framepayments.framesdk.subscriptionphases
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based operations for managing subscription phases.
+ */
 object SubscriptionPhasesAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new phase for the specified subscription.
+     *
+     * @param subscriptionId The ID of the subscription to add the phase to.
+     * @param request The details of the phase to create.
+     * @return A pair of the created [SubscriptionPhase] and any [NetworkingError] that occurred.
+     */
     suspend fun createSubscriptionPhase(subscriptionId: String, request: SubscriptionPhaseRequest.CreateSubscriptionPhaseRequest): Pair<SubscriptionPhase?, NetworkingError?> {
         val endpoint = SubscriptionPhaseEndpoints.CreateSubscriptionPhase(subscriptionId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(FrameNetworking.parseResponse<SubscriptionPhase>(data), error)
     }
 
+    /**
+     * Updates an existing phase on the specified subscription.
+     *
+     * @param subscriptionId The ID of the subscription that owns the phase.
+     * @param phaseId The ID of the phase to update.
+     * @param request The fields to update on the phase.
+     * @return A pair of the updated [SubscriptionPhase] and any [NetworkingError] that occurred.
+     */
     suspend fun updateSubscriptionPhase(subscriptionId: String, phaseId: String, request: SubscriptionPhaseRequest.UpdateSubscriptionPhaseRequest): Pair<SubscriptionPhase?, NetworkingError?> {
         val endpoint = SubscriptionPhaseEndpoints.UpdateSubscriptionPhase(subscriptionId, phaseId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(FrameNetworking.parseResponse<SubscriptionPhase>(data), error)
     }
 
+    /**
+     * Fetches a single phase by ID from the specified subscription.
+     *
+     * @param subscriptionId The ID of the subscription that owns the phase.
+     * @param phaseId The ID of the phase to retrieve.
+     * @return A pair of the matching [SubscriptionPhase] and any [NetworkingError] that occurred.
+     */
     suspend fun getSubscriptionPhaseWith(subscriptionId: String, phaseId: String): Pair<SubscriptionPhase?, NetworkingError?> {
         val endpoint = SubscriptionPhaseEndpoints.GetSubscriptionPhaseWith(subscriptionId, phaseId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(FrameNetworking.parseResponse<SubscriptionPhase>(data), error)
     }
 
+    /**
+     * Fetches all phases for the specified subscription.
+     *
+     * @param subscriptionId The ID of the subscription whose phases to retrieve.
+     * @return A pair of a [ListSubscriptionPhaseResponse] and any [NetworkingError] that occurred.
+     */
     suspend fun getSubscriptionPhases(subscriptionId: String): Pair<ListSubscriptionPhaseResponse?, NetworkingError?> {
         val endpoint = SubscriptionPhaseEndpoints.GetSubscriptionPhases(subscriptionId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(FrameNetworking.parseResponse<ListSubscriptionPhaseResponse>(data), error)
     }
 
+    /**
+     * Replaces all phases on the specified subscription in a single request.
+     *
+     * @param subscriptionId The ID of the subscription whose phases to replace.
+     * @param request The full set of phases to apply.
+     * @return A pair of the updated list of [SubscriptionPhase] objects and any [NetworkingError] that occurred.
+     */
     suspend fun bulkUpdateSubscriptionPhases(subscriptionId: String, request: SubscriptionPhaseRequest.BulkUpdateSubscriptionPhaseRequest) : Pair<List<SubscriptionPhase>?, NetworkingError?> {
         val endpoint = SubscriptionPhaseEndpoints.BulkUpdateSubscriptionPhases(subscriptionId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(FrameNetworking.parseResponse<ListSubscriptionPhaseResponse>(data)?.phases, error)
     }
 
+    /**
+     * Deletes a single phase from the specified subscription.
+     *
+     * @param subscriptionId The ID of the subscription that owns the phase.
+     * @param phaseId The ID of the phase to delete.
+     * @return A [NetworkingError] if the request failed, or null on success.
+     */
     suspend fun deleteSubscriptionPhaseWith(subscriptionId: String, phaseId: String): NetworkingError? {
         val endpoint = SubscriptionPhaseEndpoints.DeleteSubscriptionPhase(subscriptionId, phaseId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -42,6 +88,14 @@ object SubscriptionPhasesAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new phase for the specified subscription and delivers the result via callback.
+     *
+     * @param subscriptionId The ID of the subscription to add the phase to.
+     * @param request The details of the phase to create.
+     * @param completionHandler Callback invoked with the created [SubscriptionPhase] and any [NetworkingError].
+     */
     fun createSubscriptionPhase(subscriptionId: String, request: SubscriptionPhaseRequest.CreateSubscriptionPhaseRequest, completionHandler: (SubscriptionPhase?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionPhaseEndpoints.CreateSubscriptionPhase(subscriptionId)
 
@@ -50,6 +104,14 @@ object SubscriptionPhasesAPI {
         }
     }
 
+    /**
+     * Updates an existing phase on the specified subscription and delivers the result via callback.
+     *
+     * @param subscriptionId The ID of the subscription that owns the phase.
+     * @param phaseId The ID of the phase to update.
+     * @param request The fields to update on the phase.
+     * @param completionHandler Callback invoked with the updated [SubscriptionPhase] and any [NetworkingError].
+     */
     fun updateSubscriptionPhase(subscriptionId: String, phaseId: String, request: SubscriptionPhaseRequest.UpdateSubscriptionPhaseRequest, completionHandler: (SubscriptionPhase?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionPhaseEndpoints.UpdateSubscriptionPhase(subscriptionId, phaseId)
 
@@ -58,6 +120,13 @@ object SubscriptionPhasesAPI {
         }
     }
 
+    /**
+     * Fetches a single phase by ID from the specified subscription and delivers the result via callback.
+     *
+     * @param subscriptionId The ID of the subscription that owns the phase.
+     * @param phaseId The ID of the phase to retrieve.
+     * @param completionHandler Callback invoked with the matching [SubscriptionPhase] and any [NetworkingError].
+     */
     fun getSubscriptionWith(subscriptionId: String, phaseId: String, completionHandler: (SubscriptionPhase?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionPhaseEndpoints.GetSubscriptionPhaseWith(subscriptionId, phaseId)
 
@@ -66,6 +135,12 @@ object SubscriptionPhasesAPI {
         }
     }
 
+    /**
+     * Fetches all phases for the specified subscription and delivers the result via callback.
+     *
+     * @param subscriptionId The ID of the subscription whose phases to retrieve.
+     * @param completionHandler Callback invoked with a [ListSubscriptionPhaseResponse] and any [NetworkingError].
+     */
     fun getSubscriptions(subscriptionId: String, completionHandler: (ListSubscriptionPhaseResponse?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionPhaseEndpoints.GetSubscriptionPhases(subscriptionId)
 
@@ -74,6 +149,13 @@ object SubscriptionPhasesAPI {
         }
     }
 
+    /**
+     * Replaces all phases on the specified subscription in a single request and delivers the result via callback.
+     *
+     * @param subscriptionId The ID of the subscription whose phases to replace.
+     * @param request The full set of phases to apply.
+     * @param completionHandler Callback invoked with the updated list of [SubscriptionPhase] objects and any [NetworkingError].
+     */
     fun bulkUpdateSubscriptionPhases(subscriptionId: String, request: SubscriptionPhaseRequest.BulkUpdateSubscriptionPhaseRequest, completionHandler: (List<SubscriptionPhase>?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionPhaseEndpoints.BulkUpdateSubscriptionPhases(subscriptionId)
 
@@ -82,6 +164,13 @@ object SubscriptionPhasesAPI {
         }
     }
 
+    /**
+     * Deletes a single phase from the specified subscription and delivers the result via callback.
+     *
+     * @param subscriptionId The ID of the subscription that owns the phase.
+     * @param phaseId The ID of the phase to delete.
+     * @param completionHandler Callback invoked with a [NetworkingError] on failure, or null on success.
+     */
     fun deleteSubscriptionPhaseWith(subscriptionId: String, phaseId: String, completionHandler: (NetworkingError?) -> Unit) {
         val endpoint = SubscriptionPhaseEndpoints.DeleteSubscriptionPhase(subscriptionId, phaseId)
 
@@ -90,4 +179,3 @@ object SubscriptionPhasesAPI {
         }
     }
 }
-

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionEndpoints.kt
@@ -2,12 +2,52 @@ package com.framepayments.framesdk.subscriptions
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints available for subscription operations.
+ *
+ * Each case maps to a specific URL path and HTTP method used by [FrameNetworking].
+ */
 sealed class SubscriptionEndpoints: FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new subscription via POST to `/v1/subscriptions`. */
     object CreateSubscription : SubscriptionEndpoints()
+
+    /**
+     * Endpoint for updating an existing subscription via PATCH to `/v1/subscriptions/{subscriptionId}`.
+     *
+     * @property subscriptionId The unique ID of the subscription to update.
+     */
     data class UpdateSubscription(val subscriptionId: String) : SubscriptionEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated list of subscriptions via GET to `/v1/subscriptions`.
+     *
+     * @property perPage Optional number of results per page.
+     * @property page Optional page number to retrieve.
+     */
     data class GetSubscriptions(val perPage: Int? = null, val page: Int? = null)  : SubscriptionEndpoints()
+
+    /**
+     * Endpoint for retrieving a single subscription via GET to `/v1/subscriptions/{subscriptionId}`.
+     *
+     * @property subscriptionId The unique ID of the subscription to retrieve.
+     */
     data class GetSubscriptionWith(val subscriptionId: String)  : SubscriptionEndpoints()
+
+    /**
+     * Endpoint for searching subscriptions via GET to `/v1/subscriptions/search`.
+     *
+     * @property status Optional subscription status to filter by (e.g., "active", "cancelled").
+     * @property createdBefore Optional Unix timestamp; returns subscriptions created before this time.
+     * @property createdAfter Optional Unix timestamp; returns subscriptions created after this time.
+     */
     data class SearchSubscriptions(val status: String? = null, val createdBefore: Int? = null, val createdAfter: Int? = null) : SubscriptionEndpoints()
+
+    /**
+     * Endpoint for cancelling a subscription via POST to `/v1/subscriptions/{subscriptionId}/cancel`.
+     *
+     * @property subscriptionId The unique ID of the subscription to cancel.
+     */
     data class CancelSubscription(val subscriptionId: String)  : SubscriptionEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionObjects.kt
@@ -1,6 +1,24 @@
 package com.framepayments.framesdk.subscriptions
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents a recurring billing subscription for a customer.
+ *
+ * @property id Unique identifier for the subscription.
+ * @property description Optional description of the subscription.
+ * @property currentPeriodStart Unix timestamp marking the start of the current billing period.
+ * @property currentPeriodEnd Unix timestamp marking the end of the current billing period.
+ * @property livemode Whether the subscription exists in live mode (true) or test mode (false).
+ * @property plan The billing plan associated with this subscription.
+ * @property currency Three-letter ISO currency code used for billing.
+ * @property status Current status of the subscription (e.g., "active", "cancelled", "past_due").
+ * @property quantity Number of units of the plan included in this subscription.
+ * @property customer ID of the customer this subscription belongs to.
+ * @property defaultPaymentMethod ID of the payment method used for recurring charges.
+ * @property subscriptionObject String identifier for the object type, always "subscription".
+ * @property created Unix timestamp of when the subscription was created.
+ * @property startDate Unix timestamp of when the subscription billing began.
+ */
 data class Subscription (
     val id: String?,
     val description: String?,
@@ -18,6 +36,19 @@ data class Subscription (
     @SerializedName("start_date") val startDate: Int?
 )
 
+/**
+ * Represents the billing plan attached to a subscription.
+ *
+ * @property id Unique identifier for the plan.
+ * @property interval Billing interval for the plan (e.g., "month", "year").
+ * @property product ID of the product this plan is associated with.
+ * @property amount Billing amount per interval in the smallest currency unit (e.g., cents).
+ * @property currency Three-letter ISO currency code for the plan amount.
+ * @property planObject String identifier for the object type, always "plan".
+ * @property active Whether the plan is currently available for new subscriptions.
+ * @property created Unix timestamp of when the plan was created.
+ * @property livemode Whether the plan exists in live mode (true) or test mode (false).
+ */
 data class SubscriptionPlan (
     val id: String?,
     val interval: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionRequests.kt
@@ -2,7 +2,20 @@ package com.framepayments.framesdk.subscriptions
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Namespace for request models used by the Subscriptions API.
+ */
 object SubscriptionRequest {
+
+    /**
+     * Request body for creating a new subscription.
+     *
+     * @property customer The ID of the customer to subscribe. Required.
+     * @property product The ID of the product the subscription is for. Required.
+     * @property currency Three-letter ISO currency code for billing. Required.
+     * @property defaultPaymentMethod The ID of the payment method to charge on each billing cycle. Required.
+     * @property description Optional description for the subscription.
+     */
     data class CreateSubscriptionRequest (
         val customer: String,
         val product: String,
@@ -11,6 +24,14 @@ object SubscriptionRequest {
         val description: String?
     )
 
+    /**
+     * Request body for updating an existing subscription.
+     *
+     * Only fields provided with non-null values are applied to the subscription.
+     *
+     * @property description Updated description for the subscription, or null to leave unchanged.
+     * @property defaultPaymentMethod Updated payment method ID for future billing cycles, or null to leave unchanged.
+     */
     data class UpdateSubscriptionRequest (
         val description: String?,
         @SerializedName("default_payment_method") val defaultPaymentMethod: String?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionsAPI.kt
@@ -3,38 +3,85 @@ import com.framepayments.framesdk.EmptyRequest
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides methods for creating, updating, retrieving, searching, and cancelling subscriptions.
+ *
+ * Each operation is available as a suspend function for coroutine-based callers
+ * and as a callback-based overload for Java or non-coroutine callers.
+ */
 object SubscriptionsAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new subscription for a customer.
+     *
+     * @param request The subscription creation parameters.
+     * @return A pair containing the created [Subscription] on success, or a [NetworkingError] on failure.
+     */
     suspend fun createSubscription(request: SubscriptionRequest.CreateSubscriptionRequest): Pair<Subscription?, NetworkingError?> {
         val endpoint = SubscriptionEndpoints.CreateSubscription
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Subscription>(data) }, error)
     }
 
+    /**
+     * Updates an existing subscription with the provided fields.
+     *
+     * @param subscriptionId The unique ID of the subscription to update.
+     * @param request The fields to update on the subscription.
+     * @return A pair containing the updated [Subscription] on success, or a [NetworkingError] on failure.
+     */
     suspend fun updateSubscription(subscriptionId: String, request: SubscriptionRequest.UpdateSubscriptionRequest): Pair<Subscription?, NetworkingError?> {
         val endpoint = SubscriptionEndpoints.UpdateSubscription(subscriptionId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Subscription>(data) }, error)
     }
 
+    /**
+     * Retrieves a single subscription by its unique identifier.
+     *
+     * @param subscriptionId The unique ID of the subscription to retrieve.
+     * @return A pair containing the matching [Subscription] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getSubscriptionWith(subscriptionId: String): Pair<Subscription?, NetworkingError?> {
         val endpoint = SubscriptionEndpoints.GetSubscriptionWith(subscriptionId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<Subscription>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of all subscriptions.
+     *
+     * @param perPage Optional number of results to return per page.
+     * @param page Optional page number to retrieve.
+     * @return A pair containing a [SubscriptionResponses.ListSubscriptionsResponse] on success, or a [NetworkingError] on failure.
+     */
     suspend fun getSubscriptions(perPage: Int?, page: Int?): Pair<SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?> {
         val endpoint = SubscriptionEndpoints.GetSubscriptions(perPage = perPage, page = page)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<SubscriptionResponses.ListSubscriptionsResponse>(data) }, error)
     }
 
+    /**
+     * Searches for subscriptions matching the given filter criteria.
+     *
+     * @param status Optional subscription status to filter by (e.g., "active", "cancelled").
+     * @param createdBefore Optional Unix timestamp; returns subscriptions created before this time.
+     * @param createdAfter Optional Unix timestamp; returns subscriptions created after this time.
+     * @return A pair containing a list of matching [Subscription] objects on success, or a [NetworkingError] on failure.
+     */
     suspend fun searchSubscriptions(status: String?, createdBefore: Int?, createdAfter: Int?) : Pair<List<Subscription>?, NetworkingError?> {
         val endpoint = SubscriptionEndpoints.SearchSubscriptions(status = status, createdBefore = createdBefore, createdAfter = createdAfter)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<SubscriptionResponses.ListSubscriptionsResponse>(data)?.data }, error)
     }
 
+    /**
+     * Cancels an active subscription immediately.
+     *
+     * @param subscriptionId The unique ID of the subscription to cancel.
+     * @return A pair containing the cancelled [Subscription] on success, or a [NetworkingError] on failure.
+     */
     suspend fun cancelSubscriptionWith(subscriptionId: String): Pair<Subscription?, NetworkingError?> {
         val endpoint = SubscriptionEndpoints.CancelSubscription(subscriptionId)
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, EmptyRequest(description = null))
@@ -42,6 +89,13 @@ object SubscriptionsAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new subscription for a customer and delivers the result via callback.
+     *
+     * @param request The subscription creation parameters.
+     * @param completionHandler Invoked with the created [Subscription] on success, or a [NetworkingError] on failure.
+     */
     fun createSubscription(request: SubscriptionRequest.CreateSubscriptionRequest, completionHandler: (Subscription?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionEndpoints.CreateSubscription
 
@@ -50,6 +104,13 @@ object SubscriptionsAPI {
         }
     }
 
+    /**
+     * Updates an existing subscription and delivers the result via callback.
+     *
+     * @param subscriptionId The unique ID of the subscription to update.
+     * @param request The fields to update on the subscription.
+     * @param completionHandler Invoked with the updated [Subscription] on success, or a [NetworkingError] on failure.
+     */
     fun updateSubscription(subscriptionId: String, request: SubscriptionRequest.UpdateSubscriptionRequest, completionHandler: (Subscription?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionEndpoints.UpdateSubscription(subscriptionId)
 
@@ -58,6 +119,12 @@ object SubscriptionsAPI {
         }
     }
 
+    /**
+     * Retrieves a single subscription by its unique identifier and delivers the result via callback.
+     *
+     * @param subscriptionId The unique ID of the subscription to retrieve.
+     * @param completionHandler Invoked with the matching [Subscription] on success, or a [NetworkingError] on failure.
+     */
     fun getSubscriptionWith(subscriptionId: String, completionHandler: (Subscription?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionEndpoints.GetSubscriptionWith(subscriptionId)
 
@@ -66,6 +133,13 @@ object SubscriptionsAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of all subscriptions and delivers the result via callback.
+     *
+     * @param perPage Optional number of results to return per page.
+     * @param page Optional page number to retrieve.
+     * @param completionHandler Invoked with a [SubscriptionResponses.ListSubscriptionsResponse] on success, or a [NetworkingError] on failure.
+     */
     fun getSubscriptions(perPage: Int?, page: Int?, completionHandler: (SubscriptionResponses.ListSubscriptionsResponse?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionEndpoints.GetSubscriptions(perPage = perPage, page = page)
 
@@ -74,6 +148,14 @@ object SubscriptionsAPI {
         }
     }
 
+    /**
+     * Searches for subscriptions matching the given filter criteria and delivers the result via callback.
+     *
+     * @param status Optional subscription status to filter by (e.g., "active", "cancelled").
+     * @param createdBefore Optional Unix timestamp; returns subscriptions created before this time.
+     * @param createdAfter Optional Unix timestamp; returns subscriptions created after this time.
+     * @param completionHandler Invoked with a list of matching [Subscription] objects on success, or a [NetworkingError] on failure.
+     */
     fun searchSubscriptions(status: String?, createdBefore: Int?, createdAfter: Int?, completionHandler: (List<Subscription>?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionEndpoints.SearchSubscriptions(status = status, createdBefore = createdBefore, createdAfter = createdAfter)
 
@@ -82,6 +164,12 @@ object SubscriptionsAPI {
         }
     }
 
+    /**
+     * Cancels an active subscription immediately and delivers the result via callback.
+     *
+     * @param subscriptionId The unique ID of the subscription to cancel.
+     * @param completionHandler Invoked with the cancelled [Subscription] on success, or a [NetworkingError] on failure.
+     */
     fun cancelSubscriptionWith(subscriptionId: String, completionHandler: (Subscription?, NetworkingError?) -> Unit) {
         val endpoint = SubscriptionEndpoints.CancelSubscription(subscriptionId)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionsResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/subscriptions/SubscriptionsResponses.kt
@@ -1,7 +1,17 @@
 package com.framepayments.framesdk.subscriptions
 import com.framepayments.framesdk.FrameMetadata
 
+/**
+ * Namespace for response models returned by the Subscriptions API.
+ */
 object SubscriptionResponses {
+
+    /**
+     * Paginated response returned when listing subscriptions.
+     *
+     * @property meta Pagination metadata for the result set, or null if unavailable.
+     * @property data List of [Subscription] objects for the current page, or null if unavailable.
+     */
     data class ListSubscriptionsResponse (
         val meta: FrameMetadata?,
         val data: List<Subscription>?

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceAPI.kt
@@ -3,15 +3,29 @@ package com.framepayments.framesdk.termsofservice
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based operations for managing Terms of Service acceptance.
+ */
 object TermsOfServiceAPI {
     // MARK: Coroutines
 
+    /**
+     * Creates a short-lived token used to record a customer's Terms of Service acceptance.
+     *
+     * @return A pair of a [TermsOfServiceObjects.TermsOfServiceTokenResponse] containing the token and any [NetworkingError] that occurred.
+     */
     suspend fun createToken(): Pair<TermsOfServiceObjects.TermsOfServiceTokenResponse?, NetworkingError?> {
         val endpoint = TermsOfServiceEndpoints.CreateToken
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, emptyMap<String, String>())
         return Pair(data?.let { FrameNetworking.parseResponse<TermsOfServiceObjects.TermsOfServiceTokenResponse>(it) }, error)
     }
 
+    /**
+     * Records a customer's acceptance of the Terms of Service using a previously created token.
+     *
+     * @param request The acceptance details including the token and optional metadata.
+     * @return A pair of a [TermsOfServiceObjects.TermsOfServiceTokenResponse] and any [NetworkingError] that occurred.
+     */
     suspend fun update(request: TermsOfServiceRequests.UpdateRequest): Pair<TermsOfServiceObjects.TermsOfServiceTokenResponse?, NetworkingError?> {
         val endpoint = TermsOfServiceEndpoints.Update
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
@@ -20,6 +34,11 @@ object TermsOfServiceAPI {
 
     // MARK: Callbacks
 
+    /**
+     * Creates a short-lived token used to record a customer's Terms of Service acceptance and delivers the result via callback.
+     *
+     * @param completionHandler Callback invoked with the [TermsOfServiceObjects.TermsOfServiceTokenResponse] and any [NetworkingError].
+     */
     fun createToken(completionHandler: (TermsOfServiceObjects.TermsOfServiceTokenResponse?, NetworkingError?) -> Unit) {
         val endpoint = TermsOfServiceEndpoints.CreateToken
         FrameNetworking.performDataTaskWithRequest(endpoint, emptyMap<String, String>()) { data, error ->
@@ -27,6 +46,12 @@ object TermsOfServiceAPI {
         }
     }
 
+    /**
+     * Records a customer's acceptance of the Terms of Service using a previously created token and delivers the result via callback.
+     *
+     * @param request The acceptance details including the token and optional metadata.
+     * @param completionHandler Callback invoked with the [TermsOfServiceObjects.TermsOfServiceTokenResponse] and any [NetworkingError].
+     */
     fun update(request: TermsOfServiceRequests.UpdateRequest, completionHandler: (TermsOfServiceObjects.TermsOfServiceTokenResponse?, NetworkingError?) -> Unit) {
         val endpoint = TermsOfServiceEndpoints.Update
         FrameNetworking.performDataTaskWithRequest(endpoint, request) { data, error ->

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceEndpoints.kt
@@ -3,8 +3,17 @@ package com.framepayments.framesdk.termsofservice
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines all API endpoints for Terms of Service operations.
+ *
+ * Both cases resolve to /v1/terms_of_service and differ only by HTTP method.
+ */
 sealed class TermsOfServiceEndpoints : FrameNetworkingEndpoints {
+
+    /** Creates a new Terms of Service acceptance token. Resolves to POST /v1/terms_of_service. */
     object CreateToken : TermsOfServiceEndpoints()
+
+    /** Records a customer's acceptance of the Terms of Service. Resolves to PATCH /v1/terms_of_service. */
     object Update : TermsOfServiceEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceObjects.kt
@@ -1,6 +1,15 @@
 package com.framepayments.framesdk.termsofservice
 
+/**
+ * Namespace for data objects returned by the Terms of Service API.
+ */
 object TermsOfServiceObjects {
+
+    /**
+     * Response containing the token generated for a Terms of Service acceptance flow.
+     *
+     * @property token Short-lived token that identifies the acceptance session; pass this token to [TermsOfServiceRequests.UpdateRequest] to record acceptance.
+     */
     data class TermsOfServiceTokenResponse(
         val token: String?
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/termsofservice/TermsOfServiceRequests.kt
@@ -2,7 +2,19 @@ package com.framepayments.framesdk.termsofservice
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Namespace for request bodies used with the Terms of Service API.
+ */
 object TermsOfServiceRequests {
+
+    /**
+     * Request body for recording a customer's Terms of Service acceptance.
+     *
+     * @property token The short-lived token obtained from [TermsOfServiceAPI.createToken]; identifies the acceptance session.
+     * @property acceptedAt Unix timestamp of when the customer accepted the Terms of Service. Defaults to the server time when omitted.
+     * @property ipAddress IP address of the customer at the time of acceptance, used for audit purposes.
+     * @property userAgent User-agent string of the customer's device at the time of acceptance, used for audit purposes.
+     */
     data class UpdateRequest(
         val token: String,
         @SerializedName("accepted_at") val acceptedAt: Int? = null,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureEndpoints.kt
@@ -2,11 +2,31 @@ package com.framepayments.framesdk.threedsecure
 
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 
+/**
+ * Defines the network endpoints for the 3D Secure Verifications API.
+ *
+ * Each case maps to a specific API route and HTTP method used by [ThreeDSecureVerificationsAPI].
+ */
 sealed class ThreeDSecureEndpoints : FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new 3D Secure verification intent (POST /v1/3ds/intents). */
     object Create3DSecureVerification : ThreeDSecureEndpoints()
+
+    /**
+     * Endpoint for retrieving an existing 3D Secure verification intent (GET /v1/3ds/intents/{id}).
+     *
+     * @property verificationId The unique identifier of the verification to retrieve.
+     */
     data class Retrieve3DSecureVerification(val verificationId: String) : ThreeDSecureEndpoints()
+
+    /**
+     * Endpoint for resending a 3D Secure verification challenge (POST /v1/3ds/intents/{id}/resend).
+     *
+     * @property verificationId The unique identifier of the verification whose challenge to resend.
+     */
     data class Resend3DSecureVerification(val verificationId: String) : ThreeDSecureEndpoints()
 
+    /** The resolved URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is Create3DSecureVerification -> "/v1/3ds/intents"
@@ -14,12 +34,14 @@ sealed class ThreeDSecureEndpoints : FrameNetworkingEndpoints {
             is Resend3DSecureVerification -> "/v1/3ds/intents/${verificationId}/resend"
         }
 
+    /** The HTTP method for this endpoint. */
     override val httpMethod: String
         get() = when (this) {
             is Retrieve3DSecureVerification -> "GET"
             else -> "POST"
         }
 
+    /** Query parameters for this endpoint; always null for 3D Secure endpoints. */
     override val queryItems: List<com.framepayments.framesdk.QueryItem>?
         get() = null
 }

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureObjects.kt
@@ -2,13 +2,37 @@ package com.framepayments.framesdk.threedsecure
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents the lifecycle status of a 3D Secure verification intent.
+ */
 enum class VerificationStatus {
+    /** The verification has been created and is awaiting customer action. */
     @SerializedName("pending") PENDING,
+
+    /** The customer successfully completed the verification challenge. */
     @SerializedName("succeeded") SUCCEEDED,
+
+    /** The verification challenge was attempted but did not succeed. */
     @SerializedName("failed") FAILED,
+
+    /** The verification challenge has been issued to the customer. */
     @SerializedName("issued") ISSUED
 }
 
+/**
+ * Represents a 3D Secure verification intent returned by the Frame API.
+ *
+ * @property id Unique identifier for this verification intent.
+ * @property customer Identifier of the customer associated with this verification.
+ * @property paymentMethod Identifier of the payment method being verified.
+ * @property verificationObject The object type string returned by the API (e.g., "3ds_intent").
+ * @property livemode Whether this verification was created in live mode.
+ * @property status The current lifecycle status of this verification.
+ * @property challengeUrl URL the merchant should present to the customer to complete the challenge.
+ * @property completed Unix timestamp (seconds) when the verification was completed, or null if not yet completed.
+ * @property created Unix timestamp (seconds) when this verification was created.
+ * @property updated Unix timestamp (seconds) when this verification was last updated.
+ */
 data class ThreeDSecureVerification(
     val id: String?,
     val customer: String?,
@@ -22,9 +46,21 @@ data class ThreeDSecureVerification(
     val updated: Int?
 )
 
+/**
+ * Represents a structured API error returned when a 3D Secure verification cannot be created.
+ *
+ * @property error The nested error detail, or null if absent.
+ */
 data class ThreeDSecureVerificationError(
     val error: VerificationError?
 ) {
+    /**
+     * Contains the details of a verification creation error.
+     *
+     * @property type Machine-readable error type identifying the failure reason (e.g., "existing_intent").
+     * @property message Human-readable description of the error.
+     * @property existingIntentId Identifier of the conflicting existing intent, if applicable.
+     */
     data class VerificationError(
         val type: String?,
         val message: String?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureRequests.kt
@@ -2,7 +2,16 @@ package com.framepayments.framesdk.threedsecure
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains request payload models for the 3D Secure Verifications API.
+ */
 object ThreeDSecureRequests {
+
+    /**
+     * Request payload for creating a new 3D Secure verification intent.
+     *
+     * @property paymentMethodId Identifier of the payment method to run 3D Secure verification against.
+     */
     data class CreateThreeDSecureVerification(
         @SerializedName("payment_method_id") val paymentMethodId: String
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureVerificationsAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/threedsecure/ThreeDSecureVerificationsAPI.kt
@@ -3,8 +3,22 @@ package com.framepayments.framesdk.threedsecure
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based functions for managing 3D Secure verifications.
+ */
 object ThreeDSecureVerificationsAPI {
 
+    /**
+     * Creates a new 3D Secure verification intent.
+     *
+     * Returns a [Triple] whose first slot holds the created [ThreeDSecureVerification] on success.
+     * When the API returns a structured error (e.g., an existing intent conflict), the second slot
+     * is populated with a [ThreeDSecureVerificationError] and the first slot is null.
+     * A transport-level failure populates the third slot with a [NetworkingError].
+     *
+     * @param request The request payload containing the payment method to verify.
+     * @return A [Triple] of ([ThreeDSecureVerification]?, [ThreeDSecureVerificationError]?, [NetworkingError]?).
+     */
     suspend fun create3DSecureVerification(
         request: ThreeDSecureRequests.CreateThreeDSecureVerification
     ): Triple<ThreeDSecureVerification?, ThreeDSecureVerificationError?, NetworkingError?> {
@@ -22,6 +36,12 @@ object ThreeDSecureVerificationsAPI {
         return Triple(null, null, error)
     }
 
+    /**
+     * Retrieves an existing 3D Secure verification by its identifier.
+     *
+     * @param verificationId The unique identifier of the verification to retrieve.
+     * @return A [Pair] of ([ThreeDSecureVerification]?, [NetworkingError]?).
+     */
     suspend fun retrieve3DSecureVerification(
         verificationId: String
     ): Pair<ThreeDSecureVerification?, NetworkingError?> {
@@ -30,6 +50,12 @@ object ThreeDSecureVerificationsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<ThreeDSecureVerification>(data) }, error)
     }
 
+    /**
+     * Resends a 3D Secure verification challenge to the customer.
+     *
+     * @param verificationId The unique identifier of the verification to resend.
+     * @return A [Pair] of ([ThreeDSecureVerification]?, [NetworkingError]?).
+     */
     suspend fun resend3DSecureVerification(
         verificationId: String
     ): Pair<ThreeDSecureVerification?, NetworkingError?> {
@@ -41,6 +67,16 @@ object ThreeDSecureVerificationsAPI {
         return Pair(data?.let { FrameNetworking.parseResponse<ThreeDSecureVerification>(data) }, error)
     }
 
+    /**
+     * Creates a new 3D Secure verification intent and delivers the result via a callback.
+     *
+     * When the API returns a structured error (e.g., an existing intent conflict), the second
+     * parameter of [completionHandler] is populated with a [ThreeDSecureVerificationError].
+     * A transport-level failure populates the third parameter with a [NetworkingError].
+     *
+     * @param request The request payload containing the payment method to verify.
+     * @param completionHandler Callback invoked with ([ThreeDSecureVerification]?, [ThreeDSecureVerificationError]?, [NetworkingError]?).
+     */
     fun create3DSecureVerification(
         request: ThreeDSecureRequests.CreateThreeDSecureVerification,
         completionHandler: (ThreeDSecureVerification?, ThreeDSecureVerificationError?, NetworkingError?) -> Unit
@@ -64,6 +100,12 @@ object ThreeDSecureVerificationsAPI {
         }
     }
 
+    /**
+     * Retrieves an existing 3D Secure verification by its identifier and delivers the result via a callback.
+     *
+     * @param verificationId The unique identifier of the verification to retrieve.
+     * @param completionHandler Callback invoked with ([ThreeDSecureVerification]?, [NetworkingError]?).
+     */
     fun retrieve3DSecureVerification(
         verificationId: String,
         completionHandler: (ThreeDSecureVerification?, NetworkingError?) -> Unit
@@ -74,6 +116,12 @@ object ThreeDSecureVerificationsAPI {
         }
     }
 
+    /**
+     * Resends a 3D Secure verification challenge to the customer and delivers the result via a callback.
+     *
+     * @param verificationId The unique identifier of the verification to resend.
+     * @param completionHandler Callback invoked with ([ThreeDSecureVerification]?, [NetworkingError]?).
+     */
     fun resend3DSecureVerification(
         verificationId: String,
         completionHandler: (ThreeDSecureVerification?, NetworkingError?) -> Unit

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferEndpoints.kt
@@ -1,12 +1,34 @@
 package com.framepayments.framesdk.transfers
+
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the network endpoints for the Transfers API.
+ *
+ * Each case maps to a specific API route and HTTP method used by [TransfersAPI].
+ */
 sealed class TransferEndpoints : FrameNetworkingEndpoints {
+
+    /** Endpoint for creating a new transfer (POST /v1/transfers). */
     object CreateTransfer : TransferEndpoints()
+
+    /**
+     * Endpoint for retrieving a single transfer by identifier (GET /v1/transfers/{id}).
+     *
+     * @property transferId The unique identifier of the transfer to retrieve.
+     */
     data class GetTransferWith(val transferId: String) : TransferEndpoints()
+
+    /**
+     * Endpoint for retrieving a paginated list of transfers (GET /v1/transfers).
+     *
+     * @property perPage The number of results per page, or null to use the API default.
+     * @property page The page number to retrieve, or null to retrieve the first page.
+     */
     data class GetTransfers(val perPage: Int?, val page: Int?) : TransferEndpoints()
 
+    /** The resolved URL path for this endpoint. */
     override val endpointURL: String
         get() = when (this) {
             is CreateTransfer, is GetTransfers ->
@@ -15,12 +37,14 @@ sealed class TransferEndpoints : FrameNetworkingEndpoints {
                 "/v1/transfers/${this.transferId}"
         }
 
+    /** The HTTP method for this endpoint. */
     override val httpMethod: String
         get() = when (this) {
             is CreateTransfer -> "POST"
             else -> "GET"
         }
 
+    /** Query parameters appended to the request URL, populated for [GetTransfers] only. */
     override val queryItems: List<QueryItem>?
         get() = when (this) {
             is GetTransfers -> {

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferObjects.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferObjects.kt
@@ -1,16 +1,55 @@
 package com.framepayments.framesdk.transfers
+
 import com.framepayments.framesdk.FrameObjects
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Represents the lifecycle status of a transfer.
+ */
 enum class TransferStatus {
+    /** The transfer has been created and is awaiting processing. */
     @SerializedName("pending") PENDING,
+
+    /** The transfer has been successfully processed and funds have moved. */
     @SerializedName("completed") COMPLETED,
+
+    /** The transfer could not be completed. */
     @SerializedName("failed") FAILED,
+
+    /** The transfer was reversed after completion. */
     @SerializedName("reversed") REVERSED,
+
+    /** The transfer was canceled before processing. */
     @SerializedName("canceled") CANCELED,
+
+    /** The transfer was blocked, typically due to compliance or risk controls. */
     @SerializedName("blocked") BLOCKED
 }
 
+/**
+ * Represents a transfer between payment methods returned by the Frame API.
+ *
+ * @property id Unique identifier for this transfer.
+ * @property status The current lifecycle status of this transfer.
+ * @property amount Transfer amount in the smallest currency unit (e.g., cents).
+ * @property currency Three-letter ISO 4217 currency code.
+ * @property description Optional description provided when the transfer was created.
+ * @property payout Identifier of the associated payout, if any.
+ * @property metadata Arbitrary key-value pairs attached to this transfer by the merchant.
+ * @property livemode Whether this transfer was created in live mode.
+ * @property created Unix timestamp (seconds) when this transfer was created.
+ * @property transferObject The object type string returned by the API (e.g., "transfer").
+ * @property platformFee Fee retained by the merchant's platform, in the smallest currency unit.
+ * @property frameFee Fee retained by Frame, in the smallest currency unit.
+ * @property totalFees Sum of all fees deducted from this transfer, in the smallest currency unit.
+ * @property grossAmount Total amount before fees, in the smallest currency unit.
+ * @property netAmount Amount received after all fees, in the smallest currency unit.
+ * @property failureReason Human-readable reason why this transfer failed, or null if not failed.
+ * @property chargeIntent Identifier of the charge intent associated with this transfer, if any.
+ * @property billingAgreement Identifier of the billing agreement associated with this transfer, if any.
+ * @property sourcePaymentMethod The payment method funds were pulled from.
+ * @property destinationPaymentMethod The payment method funds were pushed to.
+ */
 data class Transfer(
     val id: String?,
     val status: TransferStatus?,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferRequests.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferRequests.kt
@@ -1,7 +1,23 @@
 package com.framepayments.framesdk.transfers
+
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains request payload models for the Transfers API.
+ */
 object TransferRequests {
+
+    /**
+     * Request payload for creating a new transfer.
+     *
+     * @property amount Transfer amount in the smallest currency unit (e.g., cents). Required.
+     * @property accountId Identifier of the destination account to receive the transfer. Required.
+     * @property currency Three-letter ISO 4217 currency code. Defaults to the account's currency if omitted.
+     * @property sourcePaymentMethodId Identifier of the payment method to pull funds from. Uses the account default if omitted.
+     * @property destinationPaymentMethodId Identifier of the payment method to push funds to. Uses the account default if omitted.
+     * @property description Optional description that appears on the transfer record.
+     * @property metadata Optional arbitrary key-value pairs to attach to the transfer.
+     */
     data class CreateTransferRequest(
         val amount: Int,
         @SerializedName("account_id") val accountId: String,

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransferResponses.kt
@@ -1,8 +1,19 @@
 package com.framepayments.framesdk.transfers
+
 import com.framepayments.framesdk.FrameMetadata
 
+/**
+ * Contains response payload models for the Transfers API.
+ */
 object TransferResponses {
-    data class ListTransfersResponse (
+
+    /**
+     * Paginated response returned when listing transfers.
+     *
+     * @property meta Pagination metadata such as total count and current page.
+     * @property data The list of [Transfer] objects on the current page.
+     */
+    data class ListTransfersResponse(
         val meta: FrameMetadata?,
         val data: List<Transfer>?
     )

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransfersAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/transfers/TransfersAPI.kt
@@ -1,21 +1,46 @@
 package com.framepayments.framesdk.transfers
+
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides suspend and callback-based functions for managing transfers.
+ */
 object TransfersAPI {
+
     //MARK: Methods using coroutines
+
+    /**
+     * Creates a new transfer.
+     *
+     * @param request The request payload describing the transfer to create.
+     * @return A [Pair] of ([Transfer]?, [NetworkingError]?).
+     */
     suspend fun createTransfer(request: TransferRequests.CreateTransferRequest): Pair<Transfer?, NetworkingError?> {
         val endpoint = TransferEndpoints.CreateTransfer
         val (data, error) = FrameNetworking.performDataTaskWithRequest(endpoint, request)
         return Pair(data?.let { FrameNetworking.parseResponse<Transfer>(data) }, error)
     }
 
+    /**
+     * Retrieves an existing transfer by its identifier.
+     *
+     * @param transferId The unique identifier of the transfer to retrieve.
+     * @return A [Pair] of ([Transfer]?, [NetworkingError]?).
+     */
     suspend fun getTransferWith(transferId: String): Pair<Transfer?, NetworkingError?> {
         val endpoint = TransferEndpoints.GetTransferWith(transferId)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
         return Pair(data?.let { FrameNetworking.parseResponse<Transfer>(data) }, error)
     }
 
+    /**
+     * Retrieves a paginated list of transfers.
+     *
+     * @param perPage The number of transfers to return per page, or null to use the API default.
+     * @param page The page number to retrieve, or null to retrieve the first page.
+     * @return A [Pair] of ([TransferResponses.ListTransfersResponse]?, [NetworkingError]?).
+     */
     suspend fun getTransfers(perPage: Int? = null, page: Int? = null): Pair<TransferResponses.ListTransfersResponse?, NetworkingError?> {
         val endpoint = TransferEndpoints.GetTransfers(perPage = perPage, page = page)
         val (data, error) = FrameNetworking.performDataTask(endpoint)
@@ -23,6 +48,13 @@ object TransfersAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Creates a new transfer and delivers the result via a callback.
+     *
+     * @param request The request payload describing the transfer to create.
+     * @param completionHandler Callback invoked with ([Transfer]?, [NetworkingError]?).
+     */
     fun createTransfer(request: TransferRequests.CreateTransferRequest, completionHandler: (Transfer?, NetworkingError?) -> Unit) {
         val endpoint = TransferEndpoints.CreateTransfer
 
@@ -31,6 +63,12 @@ object TransfersAPI {
         }
     }
 
+    /**
+     * Retrieves an existing transfer by its identifier and delivers the result via a callback.
+     *
+     * @param transferId The unique identifier of the transfer to retrieve.
+     * @param completionHandler Callback invoked with ([Transfer]?, [NetworkingError]?).
+     */
     fun getTransferWith(transferId: String, completionHandler: (Transfer?, NetworkingError?) -> Unit) {
         val endpoint = TransferEndpoints.GetTransferWith(transferId)
 
@@ -39,6 +77,13 @@ object TransfersAPI {
         }
     }
 
+    /**
+     * Retrieves a paginated list of transfers and delivers the result via a callback.
+     *
+     * @param perPage The number of transfers to return per page, or null to use the API default.
+     * @param page The page number to retrieve, or null to retrieve the first page.
+     * @param completionHandler Callback invoked with ([TransferResponses.ListTransfersResponse]?, [NetworkingError]?).
+     */
     fun getTransfers(perPage: Int?, page: Int?, completionHandler: (TransferResponses.ListTransfersResponse?, NetworkingError?) -> Unit) {
         val endpoint = TransferEndpoints.GetTransfers(perPage = perPage, page = page)
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/wallet/WalletAPI.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/wallet/WalletAPI.kt
@@ -3,8 +3,20 @@ package com.framepayments.framesdk.wallet
 import com.framepayments.framesdk.FrameNetworking
 import com.framepayments.framesdk.NetworkingError
 
+/**
+ * Provides wallet-related API operations, including Google Pay configuration retrieval.
+ *
+ * Each operation is available as both a coroutine suspend function and a callback-based overload.
+ */
 object WalletAPI {
     //MARK: Methods using coroutines
+
+    /**
+     * Fetches the Google Pay merchant configuration using the merchant's publishable key.
+     *
+     * @return A [Pair] where the first element is the [WalletResponses.GetGooglePayConfigurationResponse]
+     *   on success, and the second element is a [NetworkingError] on failure; one of the two will be null.
+     */
     suspend fun getGooglePayConfiguration(): Pair<WalletResponses.GetGooglePayConfigurationResponse?, NetworkingError?> {
         val endpoint = WalletEndpoints.GetGooglePayConfiguration
         val (data, error) = FrameNetworking.performDataTask(endpoint, usePublishableKey = true)
@@ -12,6 +24,14 @@ object WalletAPI {
     }
 
     //MARK: Methods using callbacks
+
+    /**
+     * Fetches the Google Pay merchant configuration using the merchant's publishable key and
+     * delivers the result to the provided callback.
+     *
+     * @param completionHandler Invoked with the parsed [WalletResponses.GetGooglePayConfigurationResponse]
+     *   on success, or a [NetworkingError] on failure; one of the two arguments will be null.
+     */
     fun getGooglePayConfiguration(completionHandler: (WalletResponses.GetGooglePayConfigurationResponse?, NetworkingError?) -> Unit) {
         val endpoint = WalletEndpoints.GetGooglePayConfiguration
 

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/wallet/WalletEndpoints.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/wallet/WalletEndpoints.kt
@@ -3,7 +3,18 @@ package com.framepayments.framesdk.wallet
 import com.framepayments.framesdk.FrameNetworkingEndpoints
 import com.framepayments.framesdk.QueryItem
 
+/**
+ * Defines the API endpoints used by wallet operations.
+ *
+ * Each case maps to a specific HTTP method and URL path used by [WalletAPI].
+ */
 sealed class WalletEndpoints : FrameNetworkingEndpoints {
+
+    /**
+     * Endpoint for retrieving the Google Pay merchant configuration.
+     *
+     * Sends a GET request to `/v1/client/wallet/google_pay`.
+     */
     object GetGooglePayConfiguration : WalletEndpoints()
 
     override val endpointURL: String

--- a/FrameSDK/src/main/java/com/framepayments/framesdk/wallet/WalletResponses.kt
+++ b/FrameSDK/src/main/java/com/framepayments/framesdk/wallet/WalletResponses.kt
@@ -2,7 +2,19 @@ package com.framepayments.framesdk.wallet
 
 import com.google.gson.annotations.SerializedName
 
+/**
+ * Contains response model types returned by wallet API operations.
+ */
 object WalletResponses {
+
+    /**
+     * The Google Pay merchant configuration returned by the wallet API.
+     *
+     * @property identifier The merchant identifier registered with Google Pay.
+     * @property environment The Google Pay environment (e.g., `"TEST"` or `"PRODUCTION"`).
+     * @property processor The payment processor associated with this merchant.
+     * @property processorKey The public key or token used to communicate with the processor.
+     */
     data class GetGooglePayConfigurationResponse(
         val identifier: String?,
         val environment: String?,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
     alias(libs.plugins.android.library) apply false
     id("com.vanniktech.maven.publish") apply false
+    alias(libs.plugins.detekt) apply false
+    alias(libs.plugins.dokka) apply false
 }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,74 @@
+# Detekt configuration for frame-android.
+# Only the KDoc documentation rules are active here; all other rule sets are disabled.
+# Run: ./gradlew detekt
+
+build:
+  maxIssues: 0
+
+# Disable every rule set except documentation.
+comments:
+  active: true
+  UndocumentedPublicClass:
+    active: true
+    excludes:
+      - "**/test/**"
+      - "**/androidTest/**"
+      - "**/sonar/**"
+      - "**/fingerprint/**"
+      - "**/managers/**"
+  UndocumentedPublicFunction:
+    active: true
+    excludes:
+      - "**/test/**"
+      - "**/androidTest/**"
+      - "**/sonar/**"
+      - "**/fingerprint/**"
+      - "**/managers/**"
+  UndocumentedPublicProperty:
+    active: true
+    excludes:
+      - "**/test/**"
+      - "**/androidTest/**"
+      - "**/sonar/**"
+      - "**/fingerprint/**"
+      - "**/managers/**"
+      - "**/*Endpoints.kt"
+  # All other comments rules off.
+  AbsentOrWrongFileLicense:
+    active: false
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+  KDocReferencesNonPublicProperty:
+    active: false
+  OutdatedDocumentation:
+    active: false
+
+complexity:
+  active: false
+
+coroutines:
+  active: false
+
+empty-blocks:
+  active: false
+
+exceptions:
+  active: false
+
+naming:
+  active: false
+
+performance:
+  active: false
+
+potential-bugs:
+  active: false
+
+style:
+  active: false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 activityCompose = "1.12.2"
 agp = "9.2.0"
+detekt = "1.23.8"
+dokka = "2.0.0"
 androidxComposeBom = "2025.12.01"
 cardview = "1.0.0"
 coil = "2.6.0"
@@ -93,4 +95,6 @@ libphonenumber = { module = "com.googlecode.libphonenumber:libphonenumber", vers
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 


### PR DESCRIPTION
- Add Detekt 1.23.8 to all three SDK modules enforcing UndocumentedPublicClass, UndocumentedPublicFunction, and UndocumentedPublicProperty (config/detekt/detekt.yml)
- Wire kdoc-lint CI job into .github/workflows/android.yml running in parallel with theme-lint
- Add Dokka 2.0.0 to all three modules; add docs.yml workflow to generate and publish Dokka HTML to GitHub Pages on release tags
- Create .agents/skills/sdk-docs/SKILL.md KDoc authoring guide for AI agents
- Backfill KDoc on every public Kotlin symbol across FrameSDK, FrameSDK-UI, and FrameSDK-Onboarding; all modules pass detekt with 0 issues

Closes FRA-4074, FRA-3959, FRA-4075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearLinkToken() to Plaid link flow.
  * New dispute retrieval endpoints in Disputes API.
  * Customer model extended with additional customer fields.

* **Documentation**
  * Introduced comprehensive KDoc standards and conventions for SDK APIs.
  * Added Detekt-based KDoc linting and CI job to enforce documentation.
  * Added workflow to publish SDK reference docs to GitHub Pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->